### PR TITLE
[Feat] 지정가 매도 로직 구현

### DIFF
--- a/src/main/java/grit/stockIt/domain/account/entity/Account.java
+++ b/src/main/java/grit/stockIt/domain/account/entity/Account.java
@@ -72,4 +72,11 @@ public class Account extends BaseEntity {
         }
         this.cash = this.cash.subtract(amount);
     }
+
+    public void increaseCash(BigDecimal amount) {
+        if (amount == null || amount.signum() <= 0) {
+            throw new IllegalArgumentException("증가 금액은 0보다 커야 합니다.");
+        }
+        this.cash = this.cash.add(amount);
+    }
 }


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->

실시간 체결량 기반 지정가 매도 로직 구현했습니다.

### ✨ Description

<!-- write down the work details and show the execution results. -->

기본적인 로직은 매수 로직과 같습니다.

매도 생성 시 해당 종목과 수량은 stock과 account를 참조하는 account_stock에 hold레코드에 묶여서 다시 매도를 하지 못하도록 하였고 취소하면 묶인 수량을 풀어줘서 다시 매도가 가능하게 했습니다.

<img width="685" height="124" alt="image" src="https://github.com/user-attachments/assets/b0f8d73b-9612-442a-8f8a-c0243ba89f07" /> <br>
10분 안에 3000원 수익 냈습니다.

사실 이 로직은 실제 거래소 주문 대기열을 고려 안 하기 때문에 매수하고 바로 매도하면 수익률이 무조건 나게 되어있습니다.
실제 시장이라면 같은 가격에서 기다리는 참가자들이 많으면 순번이 뒤에 밀려서, 그동안 생긴 체결량 중 차례가 오지 않습니다.

해당 문제를 해결하기 위해 수수료같은 걸 도입 할 예정입니다.

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #{41}
