### PR TITLE
[Feat] 주식 검색 기능 구현

### DIFF
--- a/src/main/java/grit/stockIt/domain/stock/controller/StockSearchController.java
+++ b/src/main/java/grit/stockIt/domain/stock/controller/StockSearchController.java
@@ -1,0 +1,30 @@
+package grit.stockIt.domain.stock.controller;
+
+import grit.stockIt.domain.stock.dto.StockSearchDto;
+import grit.stockIt.domain.stock.service.StockSearchService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/stocks")
+@RequiredArgsConstructor
+@Tag(name = "Stock", description = "종목 관련 API")
+public class StockSearchController {
+
+    private final StockSearchService stockSearchService;
+
+    @Operation(summary = "종목 검색", description = "종목명을 기준으로 자카드 유사도 내림차순으로 결과 반환(유사도 0 초과)")
+    @GetMapping("/search")
+    public ResponseEntity<List<StockSearchDto>> searchStocks(@RequestParam(name = "q") String q) {
+        List<StockSearchDto> results = stockSearchService.searchByName(q);
+        return ResponseEntity.ok(results);
+    }
+}

--- a/src/main/java/grit/stockIt/domain/stock/dto/StockSearchDto.java
+++ b/src/main/java/grit/stockIt/domain/stock/dto/StockSearchDto.java
@@ -1,0 +1,7 @@
+package grit.stockIt.domain.stock.dto;
+
+public record StockSearchDto(
+        String stockCode,
+        String stockName,
+        double similarity
+) {}

--- a/src/main/java/grit/stockIt/domain/stock/service/StockSearchService.java
+++ b/src/main/java/grit/stockIt/domain/stock/service/StockSearchService.java
@@ -1,0 +1,119 @@
+package grit.stockIt.domain.stock.service;
+
+import grit.stockIt.domain.stock.dto.StockSearchDto;
+import grit.stockIt.domain.stock.entity.Stock;
+import grit.stockIt.domain.stock.repository.StockRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class StockSearchService {
+
+    private final StockRepository stockRepository;
+
+    public List<StockSearchDto> searchByName(String query) {
+        if (query == null || query.trim().isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        String normalizedQuery = normalize(query);
+
+        List<Stock> stocks = stockRepository.findAll();
+
+        // 계산 및 필터링
+        List<StockSearchDto> matches = new ArrayList<>();
+        for (Stock s : stocks) {
+            String name = s.getName();
+            String normalizedName = normalize(name);
+            double sim;
+            // n-gram 기반 Jaccard (2-gram). 짧은 문자열은 문자 기반으로 폴백
+            if (normalizedQuery.length() < 2 || normalizedName.length() < 2) {
+                sim = jaccardSimilarity(normalizedQuery, normalizedName);
+            } else {
+                sim = jaccardByNGram(normalizedQuery, normalizedName, 2);
+            }
+            if (sim > 0d) {
+                matches.add(new StockSearchDto(s.getCode(), s.getName(), sim));
+            }
+        }
+
+        // 유사도 내림차순 정렬
+        return matches.stream()
+                .sorted(Comparator.comparingDouble(StockSearchDto::similarity).reversed())
+                .collect(Collectors.toList());
+    }
+
+    private static String normalize(String s) {
+        if (s == null) return "";
+        // 소문자화, 특수문자 제거(한글,영문,숫자,공백만 허용), 공백 제거(ngram 생성용)
+        String replaced = s.replaceAll("[^가-힣0-9a-zA-Z\\s]", "");
+        // 회사명 검색에서는 공백을 제거하여 'LG 화학'과 'LG화학'을 동일하게 처리
+        return replaced.replaceAll("\\s+", "").toLowerCase().trim();
+    }
+
+    // 문자 기반 멀티셋 Jaccard (교집합/합집합)
+    private static double jaccardSimilarity(String s1, String s2) {
+        if (s1 == null) s1 = "";
+        if (s2 == null) s2 = "";
+        if (s1.isEmpty() && s2.isEmpty()) return 0d;
+
+        Map<Character, Integer> m1 = new HashMap<>();
+        Map<Character, Integer> m2 = new HashMap<>();
+
+        for (char c : s1.toCharArray()) {
+            m1.put(c, m1.getOrDefault(c, 0) + 1);
+        }
+        for (char c : s2.toCharArray()) {
+            m2.put(c, m2.getOrDefault(c, 0) + 1);
+        }
+
+        Set<Character> union = new HashSet<>();
+        union.addAll(m1.keySet());
+        union.addAll(m2.keySet());
+
+        double inter = 0d;
+        double uni = 0d;
+
+        for (Character c : union) {
+            int v1 = m1.getOrDefault(c, 0);
+            int v2 = m2.getOrDefault(c, 0);
+            inter += Math.min(v1, v2);
+            uni += Math.max(v1, v2);
+        }
+
+        if (uni == 0d) return 0d;
+        return inter / uni;
+    }
+
+    // n-gram 기반 Jaccard (set 기반)
+    private static double jaccardByNGram(String s1, String s2, int n) {
+        Set<String> a = toNGrams(s1, n);
+        Set<String> b = toNGrams(s2, n);
+        if (a.isEmpty() && b.isEmpty()) return 0d;
+        Set<String> inter = new HashSet<>(a);
+        inter.retainAll(b);
+        Set<String> uni = new HashSet<>(a);
+        uni.addAll(b);
+        if (uni.size() == 0) return 0d;
+        return (double) inter.size() / (double) uni.size();
+    }
+
+    private static Set<String> toNGrams(String s, int n) {
+        Set<String> out = new HashSet<>();
+        if (s == null) return out;
+        int len = s.length();
+        if (len == 0) return out;
+        if (len < n) {
+            out.add(s);
+            return out;
+        }
+        for (int i = 0; i + n <= len; i++) {
+            out.add(s.substring(i, i + n));
+        }
+        return out;
+    }
+}

--- a/src/main/java/grit/stockIt/job/runner/OneTimeMasterFileUpdater.java
+++ b/src/main/java/grit/stockIt/job/runner/OneTimeMasterFileUpdater.java
@@ -1,0 +1,37 @@
+package grit.stockIt.job.runner;
+
+import grit.stockIt.job.service.MasterFileUpdateService;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+/**
+ * 개발/시연용: 애플리케이션 시작 시 조건부로 마스터파일 업데이트를 한 번 실행합니다.
+ * 활성화 방법: application-local.yml 또는 실행 시 JVM 파라미터에
+ * -Dapp.run-master-update-on-startup=true 를 추가하세요.
+ *
+ * 주의: 이 클래스는 로컬/시연용입니다. 실행 후에는 삭제하거나, 운영에서는 property를 false로 설정하세요.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.run-master-update-on-startup", havingValue = "true")
+public class OneTimeMasterFileUpdater implements ApplicationRunner {
+
+    private final MasterFileUpdateService masterFileUpdateService;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        log.info("OneTimeMasterFileUpdater: 시작(조건부 실행)");
+        try {
+            masterFileUpdateService.updateMasterFiles();
+            log.info("OneTimeMasterFileUpdater: 마스터파일 업데이트 완료");
+        } catch (Exception e) {
+            log.error("OneTimeMasterFileUpdater: 업데이트 중 오류", e);
+        }
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -22,3 +22,8 @@ spring:
         highlight_sql: true
         format_sql: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
+
+# 개발/시연용: 애플리케이션 시작 시 마스터파일 업데이트를 한 번 실행하려면 true로 설정
+# 실행 후에는 반드시 false로 변경하세요.
+app:
+  run-master-update-on-startup: true


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->
 - 자카드 유사도 알고리즘을 이용한 주식 검색 API 개발
 - job/runner 경로에 강제로 주식 정보 DB에 넣는 스크립트 추가
---

### ✨ Description

<!-- write down the work details and show the execution results. -->

검색 단일 기능이라 새로운 도메인 안 만들고 stock도메인에 구현했습니다.

GET /api/stocks/search
설명: 쿼리 파라미터 **q** 로 전달된 문자열로 종목명 유사도 검색을 수행합니다.

로직 설명
1. 쿼리 파라미터로 받은 문자열 정규화를 통해 이모티콘, 특수기호, 공백등의 문자를 제거합니다.
2. N-gram 비교를 위해 주식 문자열, 검색 문자열을 N자 단위로 멀티셋을 생성합니다.
3. 검색 문자열과 각 주식 이름을 자카드 유사도 알고리즘으로 비교해서 나온 유사도 값(0-1)을 기준으로 내림차순으로 정렬합니다.
4. 유사도 값이 0초과인 주식들만 리턴

오탈자를 포함해 검색해도 유사한 종목이 검색 되는 것을 볼 수 있습니다.
<img width="701" height="252" alt="image" src="https://github.com/user-attachments/assets/2b41da46-1b8c-4796-81de-c28946296f63" />
<img width="1014" height="593" alt="image" src="https://github.com/user-attachments/assets/38590757-371e-4df6-9a45-b04b0d8c9ec2" />


---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #45 
