### PR TITLE
[Feat] 멤버 정보 get, update API 구현

### DIFF
--- a/src/main/java/grit/stockIt/domain/member/controller/MemberController.java
+++ b/src/main/java/grit/stockIt/domain/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import grit.stockIt.domain.member.dto.MemberLoginRequest;
 import grit.stockIt.domain.member.dto.MemberResponse;
 import grit.stockIt.domain.member.dto.MemberSignupRequest;
 import grit.stockIt.domain.member.dto.NotificationSettingsRequest;
+import grit.stockIt.domain.member.dto.MemberUpdateRequest;
 import grit.stockIt.domain.member.service.LocalMemberService;
 import grit.stockIt.global.jwt.JwtToken;
 import io.swagger.v3.oas.annotations.Operation;
@@ -63,6 +64,34 @@ public class MemberController {
         log.info("로그아웃: {}", email);
         
         return ResponseEntity.ok("로그아웃되었습니다.");
+    }
+
+    @Operation(summary = "내 정보 조회", description = "현재 로그인한 사용자의 정보를 반환합니다.")
+    @GetMapping("/me")
+    public ResponseEntity<MemberResponse> getMyInfo() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+        if (auth == null || !auth.isAuthenticated() || "anonymousUser".equals(auth.getPrincipal())) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        String email = auth.getName();
+        MemberResponse resp = memberService.getMemberByEmail(email);
+        return ResponseEntity.ok(resp);
+    }
+
+    @Operation(summary = "내 정보 수정", description = "현재 로그인한 사용자의 프로필 및 설정을 수정합니다.")
+    @PutMapping("/me")
+    public ResponseEntity<MemberResponse> updateMyInfo(@RequestBody MemberUpdateRequest request) {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+        if (auth == null || !auth.isAuthenticated() || "anonymousUser".equals(auth.getPrincipal())) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        String email = auth.getName();
+        MemberResponse updated = memberService.updateMember(email, request);
+        return ResponseEntity.ok(updated);
     }
 
     @Operation(summary = "FCM 토큰 등록/업데이트", description = "FCM 푸시 알림을 받기 위한 토큰을 등록하거나 업데이트합니다.")

--- a/src/main/java/grit/stockIt/domain/member/dto/MemberResponse.java
+++ b/src/main/java/grit/stockIt/domain/member/dto/MemberResponse.java
@@ -24,6 +24,8 @@ public class MemberResponse {
     private String profileImage;
     private String provider; // LOCAL, KAKAO
     private LocalDateTime createdAt;
+    private boolean twoFactorEnabled;
+    private boolean notificationAgreement;
 
     public static MemberResponse from(Member member) {
         return MemberResponse.builder()
@@ -33,6 +35,8 @@ public class MemberResponse {
                 .profileImage(member.getProfileImage())
                 .provider(member.getProvider() != null ? member.getProvider().name() : null)
                 .createdAt(member.getCreatedAt())
+                .twoFactorEnabled(member.isTwoFactorEnabled())
+                .notificationAgreement(member.isNotificationAgreement())
                 .build();
     }
 }

--- a/src/main/java/grit/stockIt/domain/member/dto/MemberSignupRequest.java
+++ b/src/main/java/grit/stockIt/domain/member/dto/MemberSignupRequest.java
@@ -25,10 +25,4 @@ public class MemberSignupRequest {
     @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
     private String password;
 
-    @NotBlank(message = "이름은 필수입니다.")
-    @Size(max = 20, message = "이름은 20자 이하여야 합니다.")
-    private String name;
-
-    @Size(max = 255, message = "프로필 이미지 경로는 255자 이하여야 합니다.")
-    private String profileImage; 
 }

--- a/src/main/java/grit/stockIt/domain/member/dto/MemberUpdateRequest.java
+++ b/src/main/java/grit/stockIt/domain/member/dto/MemberUpdateRequest.java
@@ -1,0 +1,22 @@
+package grit.stockIt.domain.member.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class MemberUpdateRequest {
+
+    // optional fields for profile update
+    private String name;
+    private String profileImage;
+
+    // nullable booleans to indicate whether client wants to change them
+    private Boolean twoFactorEnabled;
+    private Boolean notificationAgreement;
+}

--- a/src/main/java/grit/stockIt/domain/member/entity/Member.java
+++ b/src/main/java/grit/stockIt/domain/member/entity/Member.java
@@ -51,6 +51,16 @@ public class Member extends BaseEntity {
     @Builder.Default
     private boolean executionNotificationEnabled = true;
 
+    // 2단계 인증 사용 여부
+    @Column(name = "two_factor_enabled", nullable = false)
+    @Builder.Default
+    private boolean twoFactorEnabled = false;
+
+    // 기타 알림 동의 여부
+    @Column(name = "notification_agreement", nullable = false)
+    @Builder.Default
+    private boolean notificationAgreement = false;
+
     /**
      * 카카오 토큰 업데이트 또는 생성
      */
@@ -84,5 +94,27 @@ public class Member extends BaseEntity {
 
     public boolean isExecutionNotificationEnabled() {
         return executionNotificationEnabled;
+    }
+
+    // 프로필 정보 업데이트
+    public void updateProfile(String name, String profileImage) {
+        if (name != null) this.name = name;
+        if (profileImage != null) this.profileImage = profileImage;
+    }
+
+    public void setTwoFactorEnabled(boolean enabled) {
+        this.twoFactorEnabled = enabled;
+    }
+
+    public void setNotificationAgreement(boolean agreed) {
+        this.notificationAgreement = agreed;
+    }
+
+    public boolean isTwoFactorEnabled() {
+        return twoFactorEnabled;
+    }
+
+    public boolean isNotificationAgreement() {
+        return notificationAgreement;
     }
 }

--- a/src/main/java/grit/stockIt/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/grit/stockIt/global/exception/GlobalExceptionHandler.java
@@ -7,16 +7,51 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.OffsetDateTime;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<Object> handleBadJson(HttpMessageNotReadableException ex, HttpServletRequest request) {
+        log.warn("JSON parse error for request {} {} : {}", request.getMethod(), request.getRequestURI(), ex.getMessage());
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("timestamp", OffsetDateTime.now().toString());
+        body.put("status", HttpStatus.BAD_REQUEST.value());
+        body.put("error", "Bad Request");
+        body.put("message", "잘못된 JSON 형식입니다.");
+        body.put("path", request.getRequestURI());
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleValidationException(MethodArgumentNotValidException ex, HttpServletRequest request) {
+        log.warn("ValidationException for request {} {}: {}", request.getMethod(), request.getRequestURI(), ex.getMessage());
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getFieldErrors().forEach(error ->
+                errors.put(error.getField(), error.getDefaultMessage())
+        );
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
+    }
+
     @ExceptionHandler(BadRequestException.class)
-    public ResponseEntity<Map<String, String>> handleBadRequestException(BadRequestException ex) {
-        log.warn("BadRequestException: {}", ex.getMessage());
+    public ResponseEntity<Map<String, String>> handleBadRequestException(BadRequestException ex, HttpServletRequest request) {
+        log.warn("BadRequestException for request {} {}: {}", request.getMethod(), request.getRequestURI(), ex.getMessage());
         Map<String, String> error = new HashMap<>();
         error.put("error", "Bad Request");
         error.put("message", ex.getMessage());
@@ -24,21 +59,26 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(ForbiddenException.class)
-    public ResponseEntity<Map<String, String>> handleForbiddenException(ForbiddenException ex) {
-        log.warn("ForbiddenException: {}", ex.getMessage());
+    public ResponseEntity<Map<String, String>> handleForbiddenException(ForbiddenException ex, HttpServletRequest request) {
+        log.warn("ForbiddenException for request {} {}: {}", request.getMethod(), request.getRequestURI(), ex.getMessage());
         Map<String, String> error = new HashMap<>();
         error.put("error", "Forbidden");
         error.put("message", ex.getMessage());
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(error);
     }
 
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<Map<String, String>> handleValidationException(MethodArgumentNotValidException ex) {
-        log.warn("ValidationException: {}", ex.getMessage());
-        Map<String, String> errors = new HashMap<>();
-        ex.getBindingResult().getFieldErrors().forEach(error -> 
-            errors.put(error.getField(), error.getDefaultMessage())
-        );
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Object> handleAll(Exception ex, HttpServletRequest request) {
+        // 전체 스택을 로깅하여 디버깅에 도움
+        log.error("Unhandled exception for request {} {}", request.getMethod(), request.getRequestURI(), ex);
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("timestamp", OffsetDateTime.now().toString());
+        body.put("status", HttpStatus.INTERNAL_SERVER_ERROR.value());
+        body.put("error", "Internal Server Error");
+        body.put("message", "서버 처리 중 오류가 발생했습니다.");
+        body.put("path", request.getRequestURI());
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(body);
     }
 }


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->
# yml파일에 ddl-auto create로 바꿔야 합니다.
제목 그대로 두 개의 API 구현 했습니다.

멤버 정보 get API의 응답 바디에서 프로필 이미지 url 속성이 null 값인 경우 반환을 안합니다.

GRT- /api/members/me
PUT- /api/members/me
---

### ✨ Description

<!-- write down the work details and show the execution results. -->

---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #65 
