### PR TITLE
feat: 대회 참가  API 구현

### DIFF
--- a/src/main/java/grit/stockIt/domain/account/dto/AccountResponse.java
+++ b/src/main/java/grit/stockIt/domain/account/dto/AccountResponse.java
@@ -1,0 +1,36 @@
+package grit.stockIt.domain.account.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import grit.stockIt.domain.account.entity.Account;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class AccountResponse {
+    private Long accountId;
+    private Long memberId;
+    private Long contestId;
+    private String accountName;
+    private BigDecimal cash;
+    private Boolean isDefault;
+
+    public static AccountResponse from(Account a) {
+        return AccountResponse.builder()
+                .accountId(a.getAccountId())
+                .memberId(a.getMember() != null ? a.getMember().getMemberId() : null)
+                .contestId(a.getContest() != null ? a.getContest().getContestId() : null)
+                .accountName(a.getAccountName())
+                .cash(a.getCash())
+                .isDefault(a.getIsDefault())
+                .build();
+    }
+}

--- a/src/main/java/grit/stockIt/domain/account/dto/JoinContestRequest.java
+++ b/src/main/java/grit/stockIt/domain/account/dto/JoinContestRequest.java
@@ -1,0 +1,17 @@
+package grit.stockIt.domain.account.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class JoinContestRequest {
+    @NotBlank(message = "계좌명은 필수입니다.")
+    private String accountName;
+}

--- a/src/main/java/grit/stockIt/domain/account/service/AccountService.java
+++ b/src/main/java/grit/stockIt/domain/account/service/AccountService.java
@@ -5,6 +5,7 @@ import grit.stockIt.domain.account.repository.AccountRepository;
 import grit.stockIt.domain.contest.entity.Contest;
 import grit.stockIt.domain.contest.repository.ContestRepository;
 import grit.stockIt.domain.member.entity.Member;
+import grit.stockIt.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -21,6 +22,7 @@ public class AccountService {
 
     private final AccountRepository accountRepository;
     private final ContestRepository contestRepository;
+    private final MemberRepository memberRepository;
 
     /**
      * 회원이 사용할 디폴트 계좌를 생성하거나 이미 있으면 반환한다.
@@ -50,6 +52,37 @@ public class AccountService {
             log.warn("Account create conflict for member={} contest={}, trying to reload", member.getMemberId(), defaultContest.getContestId());
             return accountRepository.findByMemberAndContest(member, defaultContest)
                     .orElseThrow(() -> ex);
+        }
+    }
+
+    /**
+     * 특정 대회에 대해 회원용 계좌를 생성합니다.
+     * - isDefault = false
+     * - 초기 cash = contest.seedMoney
+     */
+    @Transactional
+    public Account createAccountForContest(Member member, Long contestId, String accountName) {
+        Contest contest = contestRepository.findById(contestId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 대회입니다."));
+
+        Optional<Account> existing = accountRepository.findByMemberAndContest(member, contest);
+        if (existing.isPresent()) {
+            throw new IllegalArgumentException("이미 해당 대회에 가입된 계좌가 존재합니다.");
+        }
+
+        Account account = Account.builder()
+                .member(member)
+                .contest(contest)
+                .accountName(accountName)
+                .cash(BigDecimal.valueOf(contest.getSeedMoney() != null ? contest.getSeedMoney() : 0L))
+                .isDefault(false)
+                .build();
+
+        try {
+            return accountRepository.save(account);
+        } catch (DataIntegrityViolationException ex) {
+            log.warn("Account create conflict member={} contest={}, reloading", member.getMemberId(), contest.getContestId());
+            return accountRepository.findByMemberAndContest(member, contest).orElseThrow(() -> ex);
         }
     }
 }


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->
Post- /api/contests/{contestId}/join API 구현 했습니다.
로직 흐름
1. 멤버 테이블, 대회 테이블과 연결 된 계좌 테이블 생성
2.  계좌 이름 입력
3. 계좌 잔액은 해당 대회 테이블의 시드머니로 함

책임 분리를 위해 대회 생성 시 방장이 자동으로 대회에 참가하는 로직은 넣지 않았습니다.
---

### ✨ Description

<!-- write down the work details and show the execution results. -->

---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #71 
