### PR TITLE
[feat/#49] 업적 시스템 완성 (랭커, 파산 신청, 카이팅, 시드 콜로니 등)

### DIFF
--- a/src/main/java/grit/stockIt/domain/mission/controller/MissionController.java
+++ b/src/main/java/grit/stockIt/domain/mission/controller/MissionController.java
@@ -5,6 +5,7 @@ import grit.stockIt.domain.mission.dto.RewardResponseDto;
 import grit.stockIt.domain.mission.entity.MissionProgress;
 import grit.stockIt.domain.mission.entity.Reward;
 import grit.stockIt.domain.mission.service.MissionService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -12,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
+import grit.stockIt.domain.mission.scheduler.MissionScheduler;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -23,7 +25,7 @@ import java.util.stream.Collectors;
 public class MissionController {
 
     private final MissionService missionService;
-
+    private final MissionScheduler missionScheduler;
     /**
      * GET /api/missions
      * 현재 사용자의 모든 미션 목록을 조회합니다.
@@ -96,5 +98,39 @@ public class MissionController {
 
         // 서비스 호출
         missionService.handlePortfolioAnalysis(email);
+    }
+
+    /**
+     * POST /api/missions/bankruptcy
+     * [신규] 인생 2회차(파산 신청)
+     */
+    @PostMapping("/bankruptcy")
+    @Operation(summary = "파산 신청 (인생 2회차)", description = "총 자산이 5만원 미만일 때 구조지원금을 신청합니다.")
+    public ResponseEntity<RewardResponseDto> applyForBankruptcy(
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        // 토큰에서 이메일(String)만 추출해서 넘김
+        String email = userDetails.getUsername();
+
+        // 서비스가 이메일로 멤버 찾아서 로직 수행
+        Reward reward = missionService.applyForBankruptcy(email);
+
+        return ResponseEntity.ok(new RewardResponseDto(reward));
+    }
+
+    /**
+     * GET /api/missions/scheduler/holding
+     * [테스트용] 홀딩 미션 업데이트 스케줄러를 강제로 실행합니다.
+     * 브라우저 주소창에서 바로 호출 가능합니다.
+     */
+    @GetMapping("/scheduler/holding")
+    @Operation(summary = "[테스트] 홀딩 미션 강제 업데이트", description = "전체 유저의 홀딩 미션(HOLDING_DAYS) 진행도를 +1 증가시킵니다.")
+    public ResponseEntity<String> forceRunHoldingScheduler() {
+        log.info("☢️ [TEST] 홀딩 미션 스케줄러 강제 실행 요청됨");
+
+        // 스케줄러의 메서드를 직접 호출 (로그 및 예외처리 포함됨)
+        missionScheduler.dailyHoldingProgressTask();
+
+        return ResponseEntity.ok("✅ 홀딩 미션 진행도 업데이트가 완료되었습니다.");
     }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -15,7 +15,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:
@@ -26,4 +26,4 @@ spring:
     defer-datasource-initialization: true
   sql:
     init:
-      mode: always
+      mode: never

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -9,7 +9,7 @@ INSERT INTO title (title_id, name, description, created_at, updated_at) VALUES
                                                                             (106, '주식 초보', '7일 연속 출석을 달성한 자', NOW(), NOW()),
                                                                             (107, '주식 중수', '15일 연속 출석을 달성한 자', NOW(), NOW()),
                                                                             (108, '주식 고수', '30일 연속 출석을 달성한 자', NOW(), NOW()),
-                                                                            (109, '랭커', '수익률 랭킹 Top 10을 달성한 자', NOW(), NOW()),
+                                                                            (109, '랭커', '랭킹 Top 10을 달성한 자', NOW(), NOW()),
                                                                             (111, '인생 2회차', '총 보유 자산이 5만원 미만으로 떨어진 자', NOW(), NOW());
 
 -- 2. 보상(Reward) 테이블 데이터
@@ -20,34 +20,34 @@ INSERT INTO reward (reward_id, description, money_amount, title_id, created_at, 
 (2, '일일 미션 공통 보상', 10000, NULL, NOW(), NOW()),
 
 -- [현실형/단타] (난이도별 금액 상향)
-(11, '현실형 중급1(횟수) 보상', 30000, NULL, NOW(), NOW()),
-(12, '현실형 중급2(거래금) 보상', 50000, NULL, NOW(), NOW()),
-(13, '현실형 고급1(횟수) 보상', 100000, NULL, NOW(), NOW()),
-(14, '현실형 고급2(수익) 보상', 200000, NULL, NOW(), NOW()),
+(11, '단타형 중급1(횟수) 보상', 30000, NULL, NOW(), NOW()),
+(12, '단타형 중급2(거래금) 보상', 50000, NULL, NOW(), NOW()),
+(13, '단타형 고급1(횟수) 보상', 100000, NULL, NOW(), NOW()),
+(14, '단타형 고급2(수익) 보상', 200000, NULL, NOW(), NOW()),
 
 -- [탐구형/스윙]
-(21, '탐구형 중급1(홀딩) 보상', 50000, NULL, NOW(), NOW()),
-(22, '탐구형 중급2(수익) 보상', 80000, NULL, NOW(), NOW()),
-(23, '탐구형 고급1(홀딩) 보상', 150000, NULL, NOW(), NOW()),
-(24, '탐구형 고급2(수익) 보상', 300000, NULL, NOW(), NOW()),
+(21, '스윙형 중급1(홀딩) 보상', 50000, NULL, NOW(), NOW()),
+(22, '스윙형 중급2(수익) 보상', 80000, NULL, NOW(), NOW()),
+(23, '스윙형 고급1(홀딩) 보상', 150000, NULL, NOW(), NOW()),
+(24, '스윙형 고급2(수익) 보상', 300000, NULL, NOW(), NOW()),
 
 -- [정투형/장기]
-(31, '정투형 중급1(홀딩) 보상', 100000, NULL, NOW(), NOW()),
-(32, '정투형 중급2(수익) 보상', 150000, NULL, NOW(), NOW()),
-(33, '정투형 고급1(홀딩) 보상', 300000, NULL, NOW(), NOW()),
-(34, '정투형 고급2(수익) 보상', 500000, NULL, NOW(), NOW()),
+(31, '장투형 중급1(홀딩) 보상', 100000, NULL, NOW(), NOW()),
+(32, '장투형 중급2(수익) 보상', 150000, NULL, NOW(), NOW()),
+(33, '장투형 고급1(홀딩) 보상', 300000, NULL, NOW(), NOW()),
+(34, '장투형 고급2(수익) 보상', 500000, NULL, NOW(), NOW()),
 
 -- [업적/칭호]
-(101, '칭호 + 5,000,000원', 5000000, 101, NOW(), NOW()),
-(102, '칭호 + 100,000원', 100000, 102, NOW(), NOW()),
-(103, '칭호 + 1,000,000원', 1000000, 103, NOW(), NOW()),
-(104, '칭호 + 1,500,000원', 1500000, 104, NOW(), NOW()),
-(105, '칭호 + 1,500,000원', 1500000, 105, NOW(), NOW()),
-(106, '칭호 + 500,000원', 500000, 106, NOW(), NOW()),
-(107, '칭호 + 1,000,000원', 1000000, 107, NOW(), NOW()),
-(108, '칭호 + 2,000,000원', 2000000, 108, NOW(), NOW()),
-(109, '칭호 + 5,000,000원', 5000000, 109, NOW(), NOW()),
-(111, '칭호 + 1,000,000원 (구조지원금)', 1000000, 111, NOW(), NOW());
+(101, '칭호 + 5,000,000원 (시드 콜로니)', 5000000, 101, NOW(), NOW()),
+(102, '칭호 + 100,000원 (달콤한 첫입)', 100000, 102, NOW(), NOW()),
+(103, '칭호 + 1,000,000원 (강형욱)', 1000000, 103, NOW(), NOW()),
+(104, '칭호 + 1,500,000원 (카이팅)', 1500000, 104, NOW(), NOW()),
+(105, '칭호 + 1,500,000원 (존버)', 1500000, 105, NOW(), NOW()),
+(106, '칭호 + 500,000원 (주식 초보)', 500000, 106, NOW(), NOW()),
+(107, '칭호 + 1,000,000원 (주식 중수)', 1000000, 107, NOW(), NOW()),
+(108, '칭호 + 2,000,000원 (주식 고수)', 2000000, 108, NOW(), NOW()),
+(109, '칭호 + 5,000,000원 (랭커)', 5000000, 109, NOW(), NOW()),
+(111, '칭호 + 3,000,000원 (구조지원금)', 3000000, 111, NOW(), NOW());
 
 -- 3. 미션(Mission) 테이블 데이터
 -- [변경] 트랙별 미션 2개씩 추가 (총 4단계 구조), 업적 미션 변경
@@ -71,17 +71,17 @@ INSERT INTO mission (mission_id, name, track, type, condition_type, goal_value, 
 -- 중급1(2일 홀딩) -> 중급2(수익률 5%) -> 고급1(7일 홀딩) -> 고급2(수익률 10%)
 INSERT INTO mission (mission_id, name, track, type, condition_type, goal_value, reward_id, next_mission_id, created_at, updated_at) VALUES
                                                                                                                                         (301, '보유 종목 2일 연속 홀딩하기', 'SWING', 'INTERMEDIATE', 'HOLDING_DAYS', 2, 21, NULL, NOW(), NOW()),
-                                                                                                                                        (302, '단일 종목 수익률 5% 달성하기', 'SWING', 'INTERMEDIATE', 'PROFIT_RATE', 5, 22, NULL, NOW(), NOW()),
+                                                                                                                                        (302, '주식 매도로 수익률 5% 달성하기', 'SWING', 'INTERMEDIATE', 'PROFIT_RATE', 5, 22, NULL, NOW(), NOW()),
                                                                                                                                         (303, '보유 종목 7일 이상 홀딩하기', 'SWING', 'ADVANCED', 'HOLDING_DAYS', 7, 23, NULL, NOW(), NOW()),
-                                                                                                                                        (304, '단일 종목 수익률 10% 달성하기', 'SWING', 'ADVANCED', 'PROFIT_RATE', 10, 24, NULL, NOW(), NOW());
+                                                                                                                                        (304, '주식 매도로 수익률 10% 달성하기', 'SWING', 'ADVANCED', 'PROFIT_RATE', 10, 24, NULL, NOW(), NOW());
 
 -- [정투형 (장기/LONG_TERM)]
 -- 중급1(7일 홀딩) -> 중급2(수익률 10%) -> 고급1(16일 홀딩) -> 고급2(수익률 30%)
 INSERT INTO mission (mission_id, name, track, type, condition_type, goal_value, reward_id, next_mission_id, created_at, updated_at) VALUES
                                                                                                                                         (401, '보유 종목 7일 연속 홀딩하기', 'LONG_TERM', 'INTERMEDIATE', 'HOLDING_DAYS', 7, 31, NULL, NOW(), NOW()),
-                                                                                                                                        (402, '단일 종목 수익률 10% 달성하기', 'LONG_TERM', 'INTERMEDIATE', 'PROFIT_RATE', 10, 32, NULL, NOW(), NOW()),
+                                                                                                                                        (402, '주식 매도로 수익률 10% 달성하기', 'LONG_TERM', 'INTERMEDIATE', 'PROFIT_RATE', 10, 32, NULL, NOW(), NOW()),
                                                                                                                                         (403, '보유 종목 16일 이상 홀딩하기', 'LONG_TERM', 'ADVANCED', 'HOLDING_DAYS', 16, 33, NULL, NOW(), NOW()),
-                                                                                                                                        (404, '단일 종목 수익률 30% 달성하기', 'LONG_TERM', 'ADVANCED', 'PROFIT_RATE', 30, 34, NULL, NOW(), NOW());
+                                                                                                                                        (404, '주식 매도로 수익률 30% 달성하기', 'LONG_TERM', 'ADVANCED', 'PROFIT_RATE', 30, 34, NULL, NOW(), NOW());
 
 -- [업적 (ACHIEVEMENT)]
 INSERT INTO mission (mission_id, name, track, type, condition_type, goal_value, reward_id, next_mission_id, created_at, updated_at) VALUES


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->
미션에 더불어 업적 시스템의 구현을 완료했습니다.
하지만 개잡주를 판별하기 위한 조건이 맞춰지지 않은 부분과 포트폴리오 분석 때 따로 API호출 없이 바로 미션 갱신되는 부분과 존버 업적에 대한 논의가 필요합니다.
---

### ✨ Description

<!-- write down the work details and show the execution results. -->

---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #{Issue Number}
