### PR TITLE
feat: 카카오 OAuth 요청들에 Redirect를 넣을 수 있도록 하고, State Parameter 추가를 통해 구분

### DIFF
--- a/src/main/java/grit/stockIt/domain/auth/client/KakaoOAuthClient.java
+++ b/src/main/java/grit/stockIt/domain/auth/client/KakaoOAuthClient.java
@@ -22,14 +22,20 @@ public class KakaoOAuthClient {
     /**
      * 인가 코드로 액세스 토큰 발급 (비동기)
      */
-    public Mono<KakaoTokenResponse> getAccessToken(String code) {
+    public Mono<KakaoTokenResponse> getAccessToken(String code, String redirectUri, String state) {
+        String body = "grant_type=authorization_code" +
+                "&client_id=" + kakaoProperties.getRestApiKey() +
+                "&redirect_uri=" + redirectUri +
+                "&code=" + code;
+
+        if (state != null) {
+            body += "&state=" + state;
+        }
+
         return webClient.post()
                 .uri("https://kauth.kakao.com/oauth/token")
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-                .bodyValue("grant_type=authorization_code" +
-                        "&client_id=" + kakaoProperties.getRestApiKey() +
-                        "&redirect_uri=" + kakaoProperties.getRedirectUri() +
-                        "&code=" + code)
+                .bodyValue(body)
                 .retrieve()
                 .bodyToMono(KakaoTokenResponse.class);
     }

--- a/src/main/java/grit/stockIt/domain/auth/controller/KakaoAuthController.java
+++ b/src/main/java/grit/stockIt/domain/auth/controller/KakaoAuthController.java
@@ -28,8 +28,11 @@ public class KakaoAuthController {
 
     @Operation(summary = "카카오 로그인 콜백", description = "카카오 OAuth 콜백 처리")
     @GetMapping("/callback")
-    public CompletableFuture<ResponseEntity<KakaoLoginResponse>> kakaoCallback(@RequestParam String code) {
-        return kakaoAuthService.login(code)
+    public CompletableFuture<ResponseEntity<KakaoLoginResponse>> kakaoCallback(
+            @RequestParam String code,
+            @RequestParam(name = "redirect_uri") String redirectUri,
+            @RequestParam(required = false) String state) {
+        return kakaoAuthService.login(code, redirectUri, state)
                 .thenApply(ResponseEntity::ok)
                 .exceptionally(ex -> {
                     log.error("카카오 로그인 처리 중 예외 발생: {}", ex.toString(), ex);
@@ -50,8 +53,7 @@ public class KakaoAuthController {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         if (auth == null || !auth.isAuthenticated() || "anonymousUser".equals(auth.getPrincipal())) {
             return CompletableFuture.completedFuture(
-                ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("인증이 필요합니다.")
-            );
+                    ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("인증이 필요합니다."));
         }
 
         String email = auth.getName();


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->
카카오 요청 시 redirect uri가 달라 500 에러가 발생하던 이슈 해결 및 State 파라미터 추가로 로그인/회원가입 구분 진행
---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #{102}
