### PR TITLE
[Fix] FCM 푸시 알림을 Data-Only 방식으로 변경

### DIFF
--- a/src/main/java/grit/stockIt/domain/notification/service/ExecutionNotificationService.java
+++ b/src/main/java/grit/stockIt/domain/notification/service/ExecutionNotificationService.java
@@ -144,7 +144,17 @@ public class ExecutionNotificationService {
         String orderMethod = event.orderMethod(); // BUY, SELL
         String orderMethodKorean = "BUY".equals(orderMethod) ? "매수" : "매도";
         
+        // 알림 제목과 내용 생성
+        String title = String.format("%s %s 체결", event.stockName(), orderMethodKorean);
+        String body = String.format("%s %d주가 %s원에 체결되었습니다", 
+                orderMethodKorean, 
+                event.quantity(), 
+                formatPrice(event.price()));
+        
         Map<String, String> data = new HashMap<>();
+        // title, body를 data에 포함 (PWA Service Worker에서 사용)
+        data.put("title", title);
+        data.put("body", body);
         data.put("type", "EXECUTION");
         data.put("executionId", String.valueOf(event.executionId()));
         data.put("orderId", String.valueOf(event.orderId()));
@@ -158,12 +168,8 @@ public class ExecutionNotificationService {
         data.put("orderMethod", orderMethod);
         data.put("executedAt", String.valueOf(System.currentTimeMillis()));
 
-        boolean success = fcmService.sendExecutionNotification( // FCM 푸시 알림 전송
+        boolean success = fcmService.sendExecutionNotification( // FCM 푸시 알림 전송 (Data-Only)
                 member.getFcmToken(),
-                event.stockName(),
-                orderMethodKorean,
-                event.quantity(),
-                formatPrice(event.price()),
                 data
         );
 


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->

알림 전송 구조를 PWA에 맞게 Data-Only 방식으로 변경했습니다.

### ✨ Description

<!-- write down the work details and show the execution results. -->

---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #{112}
