### PR TITLE
[Feat] 주문 체결 로직 사용자 자산 비관적 락 도입

### DIFF
--- a/src/main/java/grit/stockIt/domain/account/repository/AccountRepository.java
+++ b/src/main/java/grit/stockIt/domain/account/repository/AccountRepository.java
@@ -89,8 +89,11 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
     Optional<Account> findByMemberIdAndContestId(@Param("memberId") Long memberId, 
                                                  @Param("contestId") Long contestId);
 
-    // 계좌 조회 (비관적 락)
+    // 계좌 조회 (비관적 락, Member와 Contest 함께 조회하여 N+1 문제 방지)
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT a FROM Account a WHERE a.accountId = :accountId")
+    @Query("SELECT a FROM Account a " +
+           "JOIN FETCH a.member m " +
+           "JOIN FETCH a.contest c " +
+           "WHERE a.accountId = :accountId")
     Optional<Account> findByIdWithLock(@Param("accountId") Long accountId);
 }


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->

### 주문 체결 로직 사용자 자산 비관적 락 도입

### ✨ Description

<!-- write down the work details and show the execution results. -->

### 분산락만으로는 막을 수 없는 상황
만약 한 사용자의 삼성전자 매수와 SK하이닉스 매수를 동시에 시도한다고 가정하겠습니다.

스레드 1: 삼성전자 Redis 락 획득 → 잔고 조회 (100만 원)
스레드 2: SK하이닉스 Redis 락 획득 → 잔고 조회 (100만 원)
이때 종목이 다르므로 Redis 락 키가 달라 동시 진입이 가능합니다.
결과: 두 서버 모두 100만 원을 기준으로 차감하여 업데이트를 시도합니다. 결국 갱신 손실(Lost Update)이 발생하여 데이터 정합성이 깨지게 됩니다.
이 문제를 해결하기 위해, 체결 로직 내부에서 사용자 계좌를 조회할 때 DB 레벨의 비관적 락(Pessimistic Lock)을 추가로 적용했습니다.


### 비관적 락 선택 이유
**1. 충돌이 잦을 것이라고 판단**

주식 체결 시스템은 특정 인기 종목이나 급변하는 시장에서 한 사용자의 계좌에 대해 매수/매도 체결이 빗발칠 수 있는 충돌 빈도가 높은 환경입니다.

**낙관적 락:** 충돌이 발생하면 예외(ObjectOptimisticLockingFailureException)를 던지고 롤백됩니다. 10건이 동시에 들어오면 1건만 성공하고 9건은 실패하여 재시도해야 합니다. 이는 어플리케이션의 CPU 자원 낭비와 불필요한 DB 커넥션 점유로 이어집니다.
**비관적 락:** 충돌 시 에러가 아닌 대기(Wait) 상태가 됩니다. 여러 스레드가 순서대로 처리되므로, 재시도로 인한 오버헤드 없이 모든 요청을 안정적으로 처리할 수 있습니다.

**2. 갱신 손실의 차단**

낙관적 락은 어플리케이션 레벨에서 버전을 체크하는 논리적인 락인 반면, 비관적 락은 데이터베이스 레벨에서 물리적으로 Row를 잠금으로써 다른 트랜잭션의 접근 자체를 차단합니다. 이를 통해 계좌를 수정하는 동안에는 다른 스레드가 읽거나 쓸 수 없게 하여 강력한 수준의 데이터 정합성을 보장합니다.

**3. 짧은 트랜잭션 길이**

비관적 락의 단점은 락을 오래 쥐고 있을 때 발생하는 성능 저하입니다. 하지만 저희 체결 로직은 계좌 조회 -> 메모리 연산 -> 업데이트로 이어지는 과정이 짧고 단순합니다. 외부 API 호출과 같은 긴 작업이 없으므로, 락 점유 시간이 짧습니다. 따라서 락 대기로 인한 병목보다 잦은 재시도 로직을 수행하는 비용이 훨씬 크다고 판단했습니다.

**4. 순서 보장의 필요성**

낙관적 락은 재시도 과정에서 먼저 들어온 요청이 나중에 처리되는 등 처리 순서가 뒤바뀔 수 있습니다. 반면 비관적 락은 DB의 Lock 획득 순서에 따라 처리되므로, 체결 이벤트의 발생 순서와 잔고 반영 순서를 최대한 일치시키는 데 유리합니다.

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #{139}
