### PR TITLE
bug: SPAC/우선주 매수 차단 기능 구현

### DIFF
--- a/src/main/java/grit/stockIt/domain/stock/analysis/dto/StockAnalysisResponse.java
+++ b/src/main/java/grit/stockIt/domain/stock/analysis/dto/StockAnalysisResponse.java
@@ -6,7 +6,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public record StockAnalysisResponse(
     @JsonProperty("stock_code") String stockCode,
     @JsonProperty("stock_name") String stockName,
-    @JsonProperty("final_style_tag") String finalStyleTag,
-    @JsonProperty("style_description") String styleDescription
+    @JsonProperty("final_style_tag") String finalStyleTag,  // style_tag alias 지원
+    @JsonProperty("style_description") String styleDescription,  // description alias 지원
+    @JsonProperty("analyzable") Boolean analyzable,  // 분석 가능 여부
+    @JsonProperty("reason") String reason            // 분석 불가 사유 (nullable)
 ) {}
 

--- a/src/main/java/grit/stockIt/domain/stock/analysis/service/PythonAnalysisClient.java
+++ b/src/main/java/grit/stockIt/domain/stock/analysis/service/PythonAnalysisClient.java
@@ -62,9 +62,17 @@ public class PythonAnalysisClient {
                             log.warn("Python 서버 재시도: {}번째 시도", retrySignal.totalRetries() + 1)
                         )
                 )
-                .onErrorMap(throwable -> {
-                    log.error("Python 서버 호출 최종 실패: {}", throwable.getMessage());
-                    return new RuntimeException("AI 서버 분석 실패: " + throwable.getMessage(), throwable);
+                .onErrorResume(throwable -> {
+                    log.error("Python 서버 호출 최종 실패: stockCode={}, error={}", request.stockCode(), throwable.getMessage());
+                    // AI 서버 오류 시 기본 응답 반환 (분석 불가로 처리)
+                    return Mono.just(new StockAnalysisResponse(
+                        request.stockCode(),
+                        null,
+                        null,
+                        null,
+                        false,
+                        "AI 서버 오류로 분석에 실패했습니다."
+                    ));
                 });
     }
 

--- a/src/main/java/grit/stockIt/domain/stock/dto/StockDetailDto.java
+++ b/src/main/java/grit/stockIt/domain/stock/dto/StockDetailDto.java
@@ -20,6 +20,10 @@ public record StockDetailDto(
     Integer highPrice,              // 최고가
     Integer lowPrice,               // 최저가
     Integer openPrice,              // 시가
-    Integer previousClosePrice      // 전일종가
+    Integer previousClosePrice,     // 전일종가
+    String styleTag,                // AI 스타일 태그 (nullable)
+    String aiDescription,           // AI 설명 (nullable)
+    Boolean tradeable,              // 거래 가능 여부
+    String untradeableReason        // 거래 불가 사유 (nullable)
 ) {}
 

--- a/src/main/java/grit/stockIt/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/grit/stockIt/global/exception/GlobalExceptionHandler.java
@@ -67,6 +67,15 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(error);
     }
 
+    @ExceptionHandler(UntradeableStockException.class)
+    public ResponseEntity<Map<String, String>> handleUntradeableStockException(UntradeableStockException ex, HttpServletRequest request) {
+        log.warn("UntradeableStockException for request {} {}: {}", request.getMethod(), request.getRequestURI(), ex.getMessage());
+        Map<String, String> error = new HashMap<>();
+        error.put("error", "Bad Request");
+        error.put("message", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Object> handleAll(Exception ex, HttpServletRequest request) {
         // 전체 스택을 로깅하여 디버깅에 도움

--- a/src/main/java/grit/stockIt/global/exception/UntradeableStockException.java
+++ b/src/main/java/grit/stockIt/global/exception/UntradeableStockException.java
@@ -1,0 +1,16 @@
+package grit.stockIt.global.exception;
+
+/**
+ * 거래 불가 종목 예외
+ */
+public class UntradeableStockException extends RuntimeException {
+    
+    public UntradeableStockException(String message) {
+        super(message);
+    }
+    
+    public UntradeableStockException() {
+        this("이 종목은 거래가 제한됩니다.");
+    }
+}
+


### PR DESCRIPTION
## 변경사항
- SPAC, 우선주 등 특수 종목 매수 차단 기능 추가
- AI 서버 `analyzable` 필드 지원
- 매수 주문 전 거래 가능 여부 검증 로직 추가

## 변경된 파일
- StockAnalysisResponse: analyzable, reason 필드 추가
- StockDetailDto: tradeable, untradeableReason 필드 추가  
- OrderService: 매수 전 검증 로직 추가
- UntradeableStockException: 예외 클래스 추가

## 테스트
- [ ] 정상 종목 조회 (tradeable: true)
- [ ] 우선주 조회 (tradeable: false)  
- [ ] 우선주 매수 차단 (400 응답)

Closes #150