### PR TITLE
[Fix] Lazy로딩으로 순환참조 문제 임시 해결

### DIFF
--- a/src/main/java/grit/stockIt/domain/stock/analysis/service/StockAnalysisService.java
+++ b/src/main/java/grit/stockIt/domain/stock/analysis/service/StockAnalysisService.java
@@ -93,16 +93,10 @@ public class StockAnalysisService {
                         return Mono.just(cachedData.get());
                     }
 
-                    // 2. 캐시에 없으면 KIS API 호출
+                    // 2. 캐시에 없으면 KIS API 호출 (순환 참조 방지를 위해 getMarketDataFromKis 사용)
                     log.info("캐시에 없어 KIS API 호출 (시장 데이터): stockCode={}", stockCode);
-                    return stockDetailService.getStockDetail(stockCode)
-                            .map(stockDetail -> {
-                                // StockDetailDto에서 시가총액, PER, PBR 추출
-                                Long marketCap = stockDetail.marketCap() != null ? stockDetail.marketCap() : null;
-                                Double per = stockDetail.per() != null ? stockDetail.per() : null;
-                                Double pbr = stockDetail.pbr() != null ? stockDetail.pbr() : null;
-
-                                MarketData data = new MarketData(marketCap, per, pbr);
+                    return stockDetailService.getMarketDataFromKis(stockCode)
+                            .map(data -> {
                                 // 3. 캐시 저장
                                 redisStockAnalysisRepository.saveMarketData(stockCode, data);
                                 return data;


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->

Lazy로딩으로 순환참조 문제 임시 해결

### ✨ Description

<!-- write down the work details and show the execution results. -->

StockDetailService가 StockAnalysisService를 의존,
StockAnalysisService가 StockDetailService를 의존
순환참조 문제 발생

@RequiredArgsConstructor 제거 후 명시적 생성자 작성
StockDetailService에 @Lazy 적용하여 프록시로 주입

-> 실제 사용 시점에 빈이 초기화되어 순환 참조 해결

**후에 새로운 서비스를 만들어서 의존성을 재설계하는 방식이 나아보임**


### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #{155}
