### PR TITLE
[Feat] Docker 로그 로테이션 및 이미지 자동 정리 설정 추가

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -156,3 +156,7 @@ jobs:
           docker compose -f docker-compose.prod.yml down
           docker compose -f docker-compose.prod.yml pull
           docker compose -f docker-compose.prod.yml up -d
+          
+          # 오래된 Docker 이미지 정리
+          docker image prune -af --filter "until=24h" || true
+          docker system prune -f --volumes || true

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,6 +15,11 @@ services:
       - ./traefik/users:/etc/traefik/users:ro
     networks:
       - backend
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
   redis:
     image: redis:7
     container_name: redis
@@ -36,6 +41,11 @@ services:
       - ./logs/redis:/var/log/redis # 로그 마운트
     networks:
       - backend
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   redis-cli:
     image: redis:7
@@ -47,6 +57,11 @@ services:
     command: [ "tail", "-f", "/dev/null" ] # 컨테이너를 계속 실행 상태로 유지
     volumes:
       - ./redis-scripts:/scripts # Redis 스크립트 디렉토리 마운트
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   backend:
     image: hwnahee/stockit:main
@@ -74,6 +89,11 @@ services:
       - FIREBASE_CREDENTIALS_BASE64=${FIREBASE_CREDENTIALS_BASE64}
       - PYTHON_ANALYSIS_URL=${PYTHON_ANALYSIS_URL}
       - GEMINI_API_KEY=${GEMINI_API_KEY}
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "5"
 
 
 volumes:


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->

### 배포 서버의 디스크 공간 부족 문제를 해결하기 위해 Docker 로그 로테이션 설정과 이미지 자동 정리 기능을 추가했습니다.

### ✨ Description

<!-- write down the work details and show the execution results. -->

- 배포 서버에서 Docker 컨테이너 로그 파일이 19GB까지 증가하여 디스크 공간 부족 발생
- 오래된 Docker 이미지가 누적되어 디스크 공간 낭비
- SCP 파일 전송 실패 (No space left on device)
<img width="512" height="176" alt="스크린샷 2026-02-02 오후 7 57 37" src="https://github.com/user-attachments/assets/071f97af-2814-4e2b-8a4f-d0aa440807fe" />

### Solution
1. Docker 로그 로테이션 설정 추가
docker-compose.prod.yml 
- 모든 서비스에 로그 크기 및 파일 수 제한 설정 
- backend: 최대 50MB × 5개 파일 (총 250MB)   
- traefik, redis, redis-cli: 최대 10MB × 3개 파일 (각 30MB)   
- 로그가 지정 크기를 넘으면 자동으로 로테이션되어 오래된 로그 삭제
2. CI/CD 파이프라인에 자동 정리 단계 추가
ci-cd.yml 
- 배포 후 24시간 이상 사용되지 않은 Docker 이미지 자동 삭제
- 미사용 컨테이너, 네트워크, 볼륨 자동 정리
- 디스크 공간을 지속적으로 확보하여 재발 방지

나중에 규모가 커지면 ELK Stack, AWS CloudWatch, Datadog 같은 곳으로 로그를 전송하여 영구 보관할 예정

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #{Issue Number}
