### PR TITLE
fix: /report/stream 422 에러 처리 및 ReportStreamRequest 직렬화 수정

### DIFF
--- a/src/main/java/grit/stockIt/domain/stock/analysis/dto/ReportStreamRequest.java
+++ b/src/main/java/grit/stockIt/domain/stock/analysis/dto/ReportStreamRequest.java
@@ -1,13 +1,13 @@
 package grit.stockIt.domain.stock.analysis.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 // Python 서버 /stock/report/stream 에 전달하는 요청 DTO
+// 직렬화: Spring Boot 글로벌 SNAKE_CASE 전략으로 stock_code, stock_name 등으로 변환
+// 역직렬화: 프론트엔드에서 전달하는 snake_case JSON → camelCase 필드
 public record ReportStreamRequest(
-    @JsonProperty("stock_code") String stockCode,
-    @JsonProperty("stock_name") String stockName,
-    @JsonProperty("style_tag") String styleTag,
-    @JsonProperty("growth_score") Double growthScore,
-    @JsonProperty("stability_score") Double stabilityScore,
-    @JsonProperty("composite_score") Double compositeScore
+    String stockCode,
+    String stockName,
+    String styleTag,
+    Double growthScore,
+    Double stabilityScore,
+    Double compositeScore
 ) {}

--- a/src/main/java/grit/stockIt/domain/stock/analysis/service/PythonAnalysisClient.java
+++ b/src/main/java/grit/stockIt/domain/stock/analysis/service/PythonAnalysisClient.java
@@ -154,8 +154,17 @@ public class PythonAnalysisClient {
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(request)
                 .retrieve()
+                .onStatus(HttpStatusCode::isError, response ->
+                    response.bodyToMono(String.class).flatMap(errorBody -> {
+                        log.error("Python /stock/report/stream 오류: stockCode={}, status={}, body={}",
+                            request.stockCode(), response.statusCode(),
+                            errorBody.length() > 300 ? errorBody.substring(0, 300) : errorBody);
+                        return Mono.error(new RuntimeException("Python HTTP " + response.statusCode()));
+                    })
+                )
                 .bodyToFlux(String.class)
-                .doOnError(e -> log.error("Python 리포트 스트리밍 실패: stockCode={}", request.stockCode(), e));
+                .doOnError(e -> log.error("Python 리포트 스트리밍 실패: stockCode={}", request.stockCode(), e))
+                .onErrorResume(e -> Flux.just("data: {\"type\": \"done\"}\n\n"));
     }
 
     // Python 서버에 포트폴리오 분석 요청


### PR DESCRIPTION
## 문제

`POST /api/stocks/{stockCode}/report/stream` 호출 시 500 에러 발생.

**원인 1**: `PythonAnalysisClient.streamReport()`에 `onErrorResume`이 없어서 AI 서버의 에러(422 등)가 그대로 500으로 전파됨.

**원인 2**: `ReportStreamRequest`의 `@JsonProperty` 어노테이션이 record 컴포넌트에서 직렬화 시 의도한 대로 동작하지 않아 AI 서버에 camelCase로 전달될 가능성 → 422 Unprocessable Entity.

## 수정 내용

- `streamReport()`: `onStatus()` + `onErrorResume()` 추가. AI 서버 에러 시 SSE `done` 이벤트 반환 (500 대신 graceful 종료)
- `ReportStreamRequest`: `@JsonProperty` 제거, `StockAnalysisRequest`와 동일하게 Spring Boot 글로벌 SNAKE_CASE 전략에 통일

## Test plan

- [ ] `POST /report/stream` 정상 요청 → SSE 스트리밍 정상 동작 확인
- [ ] AI 서버 다운 상태에서 `POST /report/stream` → 500 대신 `data: {"type": "done"}` 응답 확인