### PR TITLE
fix: ReportStreamRequest @JsonProperty 복원 (422 해결)

### DIFF
--- a/src/main/java/grit/stockIt/domain/stock/analysis/dto/ReportStreamRequest.java
+++ b/src/main/java/grit/stockIt/domain/stock/analysis/dto/ReportStreamRequest.java
@@ -1,13 +1,14 @@
 package grit.stockIt.domain.stock.analysis.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 // Python 서버 /stock/report/stream 에 전달하는 요청 DTO
-// 직렬화: Spring Boot 글로벌 SNAKE_CASE 전략으로 stock_code, stock_name 등으로 변환
-// 역직렬화: 프론트엔드에서 전달하는 snake_case JSON → camelCase 필드
+// @JsonProperty: WebClient가 글로벌 SNAKE_CASE 전략을 사용하지 않으므로 명시적 매핑 필요
 public record ReportStreamRequest(
-    String stockCode,
-    String stockName,
-    String styleTag,
-    Double growthScore,
-    Double stabilityScore,
-    Double compositeScore
+    @JsonProperty("stock_code") String stockCode,
+    @JsonProperty("stock_name") String stockName,
+    @JsonProperty("style_tag") String styleTag,
+    @JsonProperty("growth_score") Double growthScore,
+    @JsonProperty("stability_score") Double stabilityScore,
+    @JsonProperty("composite_score") Double compositeScore
 ) {}


### PR DESCRIPTION
## 문제

`POST /report/stream` 호출 시 AI 서버에 camelCase로 전달되어 422 → `done` 이벤트만 반환.

## 원인

WebClient가 Spring Boot 글로벌 SNAKE_CASE 전략을 사용하지 않아
`stockCode` (camelCase) → AI 서버가 `stock_code` (snake_case) 기대 → 422.

## 수정

`@JsonProperty` 복원으로 명시적 snake_case 직렬화 보장.