### PR TITLE
feat: /score 포트폴리오+페르소나 기반 유사도 계산 지원

### DIFF
--- a/src/main/java/grit/stockIt/domain/stock/analysis/controller/StockAnalysisController.java
+++ b/src/main/java/grit/stockIt/domain/stock/analysis/controller/StockAnalysisController.java
@@ -1,6 +1,7 @@
 package grit.stockIt.domain.stock.analysis.controller;
 
 import grit.stockIt.domain.stock.analysis.dto.ReportStreamRequest;
+import grit.stockIt.domain.stock.analysis.dto.ScoreRequest;
 import grit.stockIt.domain.stock.analysis.dto.StockAnalysisResponse;
 import grit.stockIt.domain.stock.analysis.service.StockAnalysisService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -34,13 +35,14 @@ public class StockAnalysisController {
         return stockAnalysisService.analyzeStock(stockCode, email);
     }
 
-    @Operation(summary = "종목 스코어링", description = "KMeans 스타일 태그 + 멀티팩터 점수만 반환 (< 1초). report/stream과 함께 사용.")
+    @Operation(summary = "종목 스코어링", description = "KMeans 스타일 태그 + 멀티팩터 점수만 반환 (< 1초). body에 포트폴리오+페르소나 포함 시 실제 유사도 계산.")
     @PostMapping("/{stockCode}/score")
     public Mono<StockAnalysisResponse> scoreStock(
             @PathVariable String stockCode,
+            @RequestBody(required = false) ScoreRequest scoreRequest,
             @AuthenticationPrincipal UserDetails userDetails) {
         String email = userDetails != null ? userDetails.getUsername() : null;
-        return stockAnalysisService.scoreStock(stockCode, email);
+        return stockAnalysisService.scoreStock(stockCode, email, scoreRequest);
     }
 
     @Operation(summary = "AI 투자 리포트 스트리밍", description = "뉴스 RAG + Gemini 리포트를 SSE로 스트리밍. 이벤트: news_ready → token(반복) → done")

--- a/src/main/java/grit/stockIt/domain/stock/analysis/dto/ScoreRequest.java
+++ b/src/main/java/grit/stockIt/domain/stock/analysis/dto/ScoreRequest.java
@@ -1,0 +1,22 @@
+package grit.stockIt.domain.stock.analysis.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+// /score 엔드포인트 요청 DTO (Optional — 없으면 기존처럼 유사도 50.0)
+public record ScoreRequest(
+    @JsonProperty("portfolio_stocks") List<PortfolioStockDto> portfolioStocks,
+    @JsonProperty("persona") String persona
+) {
+    public record PortfolioStockDto(
+        @JsonProperty("stock_code") String stockCode,
+        @JsonProperty("market_cap") Double marketCap,
+        @JsonProperty("per") Double per,
+        @JsonProperty("pbr") Double pbr,
+        @JsonProperty("roe") Double roe,
+        @JsonProperty("debt_ratio") Double debtRatio,
+        @JsonProperty("dividend_yield") Double dividendYield,
+        @JsonProperty("investment_amount") Double investmentAmount
+    ) {}
+}

--- a/src/main/java/grit/stockIt/domain/stock/analysis/service/PythonAnalysisClient.java
+++ b/src/main/java/grit/stockIt/domain/stock/analysis/service/PythonAnalysisClient.java
@@ -5,6 +5,7 @@ import grit.stockIt.domain.stock.analysis.dto.PortfolioAnalysisResponse;
 import grit.stockIt.domain.stock.analysis.dto.RecommendRequest;
 import grit.stockIt.domain.stock.analysis.dto.RecommendResponse;
 import grit.stockIt.domain.stock.analysis.dto.ReportStreamRequest;
+import grit.stockIt.domain.stock.analysis.dto.ScoreRequest;
 import grit.stockIt.domain.stock.analysis.dto.StockAnalysisRequest;
 import grit.stockIt.domain.stock.analysis.dto.StockAnalysisResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -111,14 +112,45 @@ public class PythonAnalysisClient {
                 });
     }
 
-    // Python 서버에 빠른 스코어링만 요청 (뉴스/LLM 없음, < 1초)
-    public Mono<StockAnalysisResponse> score(StockAnalysisRequest request) {
-        log.info("Python 서버 스코어링 요청: stockCode={}", request.stockCode());
+    // Python 서버에 빠른 스코어링만 요청 (포트폴리오 있으면 실제 유사도 계산)
+    public Mono<StockAnalysisResponse> score(StockAnalysisRequest request, ScoreRequest scoreRequest) {
+        log.info("Python 서버 스코어링 요청: stockCode={}, hasPortfolio={}",
+                request.stockCode(), scoreRequest != null && scoreRequest.portfolioStocks() != null);
+
+        // 명시적 snake_case Map 구성 (WebClient 직렬화 이슈 방지)
+        java.util.Map<String, Object> body = new java.util.HashMap<>();
+        body.put("stock_code", request.stockCode());
+        body.put("market_cap", request.marketCap() != null ? request.marketCap() : 0.0);
+        body.put("per", request.per() != null ? request.per() : 0.0);
+        body.put("pbr", request.pbr() != null ? request.pbr() : 0.0);
+        body.put("roe", request.roe() != null ? request.roe() : 0.0);
+        body.put("debt_ratio", request.debtRatio() != null ? request.debtRatio() : 0.0);
+        body.put("dividend_yield", request.dividendYield() != null ? request.dividendYield() : 0.0);
+
+        // 포트폴리오 + 페르소나 추가 (있으면)
+        if (scoreRequest != null && scoreRequest.portfolioStocks() != null) {
+            java.util.List<java.util.Map<String, Object>> portfolioList = scoreRequest.portfolioStocks().stream()
+                    .map(s -> java.util.Map.<String, Object>of(
+                            "stock_code", s.stockCode(),
+                            "market_cap", s.marketCap() != null ? s.marketCap() : 0.0,
+                            "per", s.per() != null ? s.per() : 0.0,
+                            "pbr", s.pbr() != null ? s.pbr() : 0.0,
+                            "roe", s.roe() != null ? s.roe() : 0.0,
+                            "debt_ratio", s.debtRatio() != null ? s.debtRatio() : 0.0,
+                            "dividend_yield", s.dividendYield() != null ? s.dividendYield() : 0.0,
+                            "investment_amount", s.investmentAmount() != null ? s.investmentAmount() : 0.0
+                    ))
+                    .toList();
+            body.put("portfolio_stocks", portfolioList);
+        }
+        if (scoreRequest != null && scoreRequest.persona() != null) {
+            body.put("persona", scoreRequest.persona());
+        }
 
         return getPythonWebClient()
                 .post()
                 .uri("/stock/score")
-                .bodyValue(request)
+                .bodyValue(body)
                 .retrieve()
                 .onStatus(HttpStatusCode::isError, response ->
                     response.bodyToMono(String.class).flatMap(errorBody -> {

--- a/src/main/java/grit/stockIt/domain/stock/analysis/service/StockAnalysisService.java
+++ b/src/main/java/grit/stockIt/domain/stock/analysis/service/StockAnalysisService.java
@@ -84,9 +84,9 @@ public class StockAnalysisService {
                 });
     }
 
-    // 빠른 스코어링만 수행 (뉴스/LLM 없음)
-    public Mono<StockAnalysisResponse> scoreStock(String stockCode, String email) {
-        log.info("종목 스코어링 시작: stockCode={}", stockCode);
+    // 빠른 스코어링만 수행 (뉴스/LLM 없음, 포트폴리오 있으면 실제 유사도 계산)
+    public Mono<StockAnalysisResponse> scoreStock(String stockCode, String email, ScoreRequest scoreRequest) {
+        log.info("종목 스코어링 시작: stockCode={}, hasPortfolio={}", stockCode, scoreRequest != null && scoreRequest.portfolioStocks() != null);
 
         Mono<MarketData> marketDataMono = getMarketData(stockCode);
         Mono<FinancialData> financialDataMono = getFinancialData(stockCode);
@@ -108,7 +108,7 @@ public class StockAnalysisService {
                             dividendData.dividendYield() != null ? dividendData.dividendYield() : 0.0
                     );
 
-                    return pythonAnalysisClient.score(request);
+                    return pythonAnalysisClient.score(request, scoreRequest);
                 })
                 .doOnSuccess(response -> {
                     if (email != null) {


### PR DESCRIPTION
## 변경 내용

- ScoreRequest DTO 추가 (Optional: portfolio_stocks, persona)
- Controller: @RequestBody(required=false) ScoreRequest 추가
- Service: scoreStock()에 ScoreRequest 파라미터 전달
- PythonClient: Map 직렬화로 portfolio_stocks + persona AI 서버에 전달
- 하위 호환: body 없이 호출하면 기존처럼 유사도 50.0

## AI 서버 PR

https://github.com/Industry-Academic-SW-Capstone/AI/pull/35 와 함께 배포 필요