### PR TITLE
feat: 포트폴리오 손익 상세 및 대회 참가자 포트폴리오 조회 API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ sequence-diagrams/
 ### Traefik ###
 traefik/users
 traefik/letsencrypt/acme.json
+
+### OMC ###
+.omc/

--- a/src/main/java/grit/stockIt/domain/account/dto/AssetResponse.java
+++ b/src/main/java/grit/stockIt/domain/account/dto/AssetResponse.java
@@ -16,8 +16,12 @@ public record AssetResponse(
             String marketType,          // 시장 구분 (KOSPI, KOSDAQ)
             int quantity,               // 보유 수량
             BigDecimal currentPrice,    // 현재가
-            BigDecimal averagePrice,    // 평단가
-            BigDecimal totalValue       // 총 평가액 (quantity × currentPrice)
+            BigDecimal averagePrice,    // 1주 평균 매입가 (평단가)
+            BigDecimal totalValue,      // 총 평가액 (quantity × currentPrice)
+            BigDecimal investmentPrincipal,  // 투자 원금 (quantity × averagePrice)
+            BigDecimal profitLossPerShare,   // 1주당 손익 (currentPrice - averagePrice)
+            BigDecimal profitLossTotal,      // 총 손익 (profitLossPerShare × quantity)
+            BigDecimal profitRate            // 수익률 % ((profitLossTotal / investmentPrincipal) × 100)
     ) {}
 }
 

--- a/src/main/java/grit/stockIt/domain/account/service/AssetService.java
+++ b/src/main/java/grit/stockIt/domain/account/service/AssetService.java
@@ -107,6 +107,17 @@ public class AssetService {
         int quantity = accountStock.getQuantity();
         BigDecimal averagePrice = accountStock.getAveragePrice();
         BigDecimal totalValue = currentPrice.multiply(BigDecimal.valueOf(quantity));
+        BigDecimal investmentPrincipal = averagePrice.multiply(BigDecimal.valueOf(quantity));
+        BigDecimal profitLossPerShare = currentPrice.subtract(averagePrice);
+        BigDecimal profitLossTotal = profitLossPerShare.multiply(BigDecimal.valueOf(quantity));
+
+        BigDecimal profitRate = BigDecimal.ZERO;
+        if (investmentPrincipal.compareTo(BigDecimal.ZERO) > 0) {
+            profitRate = profitLossTotal
+                    .divide(investmentPrincipal, 4, RoundingMode.HALF_UP)
+                    .multiply(BigDecimal.valueOf(100))
+                    .setScale(2, RoundingMode.HALF_UP);
+        }
 
         return new AssetResponse.HoldingItem(
                 accountStock.getStock().getCode(),
@@ -115,7 +126,11 @@ public class AssetService {
                 quantity,
                 currentPrice,
                 averagePrice,
-                totalValue
+                totalValue,
+                investmentPrincipal,
+                profitLossPerShare,
+                profitLossTotal,
+                profitRate
         );
     }
 

--- a/src/main/java/grit/stockIt/domain/ranking/controller/RankingController.java
+++ b/src/main/java/grit/stockIt/domain/ranking/controller/RankingController.java
@@ -1,8 +1,11 @@
 package grit.stockIt.domain.ranking.controller;
 
+import grit.stockIt.domain.ranking.dto.MemberPortfolioResponse;
 import grit.stockIt.domain.ranking.dto.MyRankDto;
 import grit.stockIt.domain.ranking.dto.RankingResponse;
 import grit.stockIt.domain.ranking.service.RankingService;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -104,6 +107,37 @@ public class RankingController {
     ) {
         log.info("🔍 [API 호출] 내 랭킹 조회 (memberId: {}, contestId: {})", memberId, contestId);
         MyRankDto response = rankingService.getMyRank(memberId, contestId);
+        return ResponseEntity.ok(response);
+    }
+
+    // ==================== 대회 참가자 포트폴리오 조회 ====================
+
+    /**
+     * 대회 참가자의 포트폴리오 조회
+     * - 같은 대회에 참가 중인 사용자만 조회 가능
+     * - 랭킹 화면에서 다른 참가자 이름 클릭 시 호출
+     *
+     * GET /api/rankings/contest/{contestId}/members/{memberId}/portfolio
+     */
+    @GetMapping("/contest/{contestId}/members/{memberId}/portfolio")
+    @Operation(
+            summary = "대회 참가자 포트폴리오 조회",
+            description = "같은 대회에 참가 중인 다른 참가자의 포트폴리오를 조회합니다. 종목별 비중, 손익 정보를 포함합니다."
+    )
+    public ResponseEntity<MemberPortfolioResponse> getMemberPortfolio(
+            @Parameter(description = "대회 ID", example = "1", required = true)
+            @PathVariable("contestId") Long contestId,
+
+            @Parameter(description = "조회 대상 회원 ID", example = "42", required = true)
+            @PathVariable("memberId") Long memberId
+    ) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String requesterEmail = authentication.getName();
+
+        log.info("[API 호출] 대회 참가자 포트폴리오 조회 (contestId: {}, memberId: {}, requester: {})",
+                contestId, memberId, requesterEmail);
+
+        MemberPortfolioResponse response = rankingService.getMemberPortfolio(contestId, memberId, requesterEmail);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/grit/stockIt/domain/ranking/dto/MemberPortfolioResponse.java
+++ b/src/main/java/grit/stockIt/domain/ranking/dto/MemberPortfolioResponse.java
@@ -1,0 +1,74 @@
+package grit.stockIt.domain.ranking.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Schema(description = "대회 참가자 포트폴리오 조회 응답")
+public record MemberPortfolioResponse(
+
+        @Schema(description = "회원 ID", example = "42")
+        Long memberId,
+
+        @Schema(description = "닉네임", example = "투자왕김씨")
+        String nickname,
+
+        @Schema(description = "프로필 이미지 URL")
+        String profileImage,
+
+        @Schema(description = "대표 칭호")
+        String representativeTitle,
+
+        @Schema(description = "총 자산", example = "12000000.00")
+        BigDecimal totalAssets,
+
+        @Schema(description = "보유 현금", example = "3000000.00")
+        BigDecimal cash,
+
+        @Schema(description = "현금 비중 (%)", example = "25.00")
+        BigDecimal cashPercent,
+
+        @Schema(description = "주식 평가액 합계", example = "9000000.00")
+        BigDecimal stockValue,
+
+        @Schema(description = "수익률 (%)", example = "20.00")
+        BigDecimal returnRate,
+
+        @Schema(description = "보유 종목 목록")
+        List<PortfolioItem> holdings
+) {
+    @Schema(description = "포트폴리오 종목 항목")
+    public record PortfolioItem(
+
+            @Schema(description = "종목 코드", example = "005930")
+            String stockCode,
+
+            @Schema(description = "종목명", example = "삼성전자")
+            String stockName,
+
+            @Schema(description = "보유 수량", example = "10")
+            int quantity,
+
+            @Schema(description = "1주 평균 매입가", example = "70000.00")
+            BigDecimal averagePrice,
+
+            @Schema(description = "현재가", example = "72000.00")
+            BigDecimal currentPrice,
+
+            @Schema(description = "종목 평가액 (quantity × currentPrice)", example = "720000.00")
+            BigDecimal totalValue,
+
+            @Schema(description = "포트폴리오 내 비중 (%)", example = "8.00")
+            BigDecimal percent,
+
+            @Schema(description = "1주당 손익", example = "2000.00")
+            BigDecimal profitLossPerShare,
+
+            @Schema(description = "총 손익", example = "20000.00")
+            BigDecimal profitLossTotal,
+
+            @Schema(description = "수익률 (%)", example = "2.86")
+            BigDecimal profitRate
+    ) {}
+}

--- a/src/main/java/grit/stockIt/domain/ranking/service/RankingService.java
+++ b/src/main/java/grit/stockIt/domain/ranking/service/RankingService.java
@@ -9,6 +9,7 @@ import grit.stockIt.domain.contest.repository.ContestRepository;
 import grit.stockIt.domain.matching.repository.RedisMarketDataRepository;
 import grit.stockIt.domain.mission.service.MissionService;
 import grit.stockIt.domain.mission.dto.UserTierStatusDto;
+import grit.stockIt.domain.ranking.dto.MemberPortfolioResponse;
 import grit.stockIt.domain.ranking.dto.MyRankDto;
 import grit.stockIt.domain.ranking.dto.RankingDto;
 import grit.stockIt.domain.ranking.dto.RankingResponse;
@@ -594,6 +595,127 @@ public class RankingService {
         }
 
         return rankings;
+    }
+
+    // ==================== 대회 참가자 포트폴리오 조회 ====================
+
+    /**
+     * 같은 대회 참가자의 포트폴리오 조회
+     * - 같은 대회에 참가 중인 사용자만 조회 가능
+     * - 원형 차트용 비중 데이터 포함
+     *
+     * @param contestId       대회 ID
+     * @param targetMemberId  조회 대상 회원 ID
+     * @param requesterEmail  요청자 이메일 (같은 대회 참가 여부 확인용)
+     * @return MemberPortfolioResponse
+     */
+    @Transactional(readOnly = true)
+    public MemberPortfolioResponse getMemberPortfolio(Long contestId, Long targetMemberId, String requesterEmail) {
+        // 1. 대회 존재 여부 확인
+        Contest contest = contestRepository.findById(contestId)
+                .orElseThrow(() -> new IllegalArgumentException("대회를 찾을 수 없습니다. (ID: " + contestId + ")"));
+
+        // 2. 요청자가 같은 대회에 참가 중인지 확인
+        List<Account> contestAccounts = accountRepository.findByContest(contest);
+        boolean isRequesterInContest = contestAccounts.stream()
+                .anyMatch(a -> a.getMember().getEmail().equals(requesterEmail));
+        if (!isRequesterInContest) {
+            throw new grit.stockIt.global.exception.ForbiddenException("같은 대회 참가자만 포트폴리오를 조회할 수 있습니다.");
+        }
+
+        // 3. 대상 회원의 대회 계좌 찾기
+        Account targetAccount = accountRepository.findByMemberIdAndContestId(targetMemberId, contestId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 회원의 대회 계좌를 찾을 수 없습니다."));
+
+        // 4. 보유 종목 조회
+        List<AccountStock> accountStocks = accountStockRepository.findByAccountIdWithStock(targetAccount.getAccountId());
+
+        // 5. 현재가 수집
+        Set<String> stockCodes = accountStocks.stream()
+                .map(as -> as.getStock().getCode())
+                .collect(Collectors.toSet());
+        Map<String, BigDecimal> currentPrices = batchFetchCurrentPrices(stockCodes);
+
+        // 6. 종목별 평가액 계산
+        BigDecimal cash = targetAccount.getCash();
+        BigDecimal stockValue = BigDecimal.ZERO;
+
+        List<MemberPortfolioResponse.PortfolioItem> holdings = new ArrayList<>();
+        for (AccountStock as : accountStocks) {
+            if (as.getQuantity() <= 0) continue;
+
+            String code = as.getStock().getCode();
+            BigDecimal currentPrice = currentPrices.getOrDefault(code, BigDecimal.ZERO);
+            BigDecimal avgPrice = as.getAveragePrice();
+            int qty = as.getQuantity();
+
+            BigDecimal totalValue = currentPrice.multiply(BigDecimal.valueOf(qty));
+            BigDecimal profitLossPerShare = currentPrice.subtract(avgPrice);
+            BigDecimal profitLossTotal = profitLossPerShare.multiply(BigDecimal.valueOf(qty));
+            BigDecimal investmentPrincipal = avgPrice.multiply(BigDecimal.valueOf(qty));
+
+            BigDecimal profitRate = BigDecimal.ZERO;
+            if (investmentPrincipal.compareTo(BigDecimal.ZERO) > 0) {
+                profitRate = profitLossTotal
+                        .divide(investmentPrincipal, 4, RoundingMode.HALF_UP)
+                        .multiply(BigDecimal.valueOf(100))
+                        .setScale(2, RoundingMode.HALF_UP);
+            }
+
+            stockValue = stockValue.add(totalValue);
+
+            holdings.add(new MemberPortfolioResponse.PortfolioItem(
+                    code, as.getStock().getName(), qty,
+                    avgPrice, currentPrice, totalValue,
+                    BigDecimal.ZERO, // percent - 아래에서 계산
+                    profitLossPerShare, profitLossTotal, profitRate
+            ));
+        }
+
+        // 7. 총자산 및 비중(%) 계산
+        BigDecimal totalAssets = cash.add(stockValue);
+
+        BigDecimal cashPercent = BigDecimal.ZERO;
+        if (totalAssets.compareTo(BigDecimal.ZERO) > 0) {
+            cashPercent = cash.divide(totalAssets, 4, RoundingMode.HALF_UP)
+                    .multiply(BigDecimal.valueOf(100))
+                    .setScale(2, RoundingMode.HALF_UP);
+        }
+
+        // 각 종목의 비중 재계산
+        List<MemberPortfolioResponse.PortfolioItem> holdingsWithPercent = holdings.stream()
+                .map(h -> {
+                    BigDecimal pct = BigDecimal.ZERO;
+                    if (totalAssets.compareTo(BigDecimal.ZERO) > 0) {
+                        pct = h.totalValue().divide(totalAssets, 4, RoundingMode.HALF_UP)
+                                .multiply(BigDecimal.valueOf(100))
+                                .setScale(2, RoundingMode.HALF_UP);
+                    }
+                    return new MemberPortfolioResponse.PortfolioItem(
+                            h.stockCode(), h.stockName(), h.quantity(),
+                            h.averagePrice(), h.currentPrice(), h.totalValue(),
+                            pct, h.profitLossPerShare(), h.profitLossTotal(), h.profitRate()
+                    );
+                })
+                .sorted((a, b) -> b.totalValue().compareTo(a.totalValue())) // 평가액 내림차순
+                .toList();
+
+        // 8. 수익률 계산
+        BigDecimal returnRate = calculateReturnRateFromAssets(totalAssets, contest);
+
+        // 9. 회원 정보
+        var member = targetAccount.getMember();
+        String title = member.getRepresentativeTitle() != null
+                ? member.getRepresentativeTitle().getName()
+                : null;
+
+        log.info("대회 참가자 포트폴리오 조회 완료: contestId={}, targetMemberId={}", contestId, targetMemberId);
+
+        return new MemberPortfolioResponse(
+                member.getMemberId(), member.getName(), member.getProfileImage(),
+                title, totalAssets, cash, cashPercent, stockValue, returnRate,
+                holdingsWithPercent
+        );
     }
 
     /**

--- a/src/test/java/grit/stockIt/domain/account/service/AssetServiceHoldingItemTest.java
+++ b/src/test/java/grit/stockIt/domain/account/service/AssetServiceHoldingItemTest.java
@@ -1,0 +1,256 @@
+package grit.stockIt.domain.account.service;
+
+import grit.stockIt.domain.account.dto.AssetResponse;
+import grit.stockIt.domain.account.entity.Account;
+import grit.stockIt.domain.account.entity.AccountStock;
+import grit.stockIt.domain.account.repository.AccountRepository;
+import grit.stockIt.domain.account.repository.AccountStockRepository;
+import grit.stockIt.domain.contest.entity.Contest;
+import grit.stockIt.domain.member.entity.AuthProvider;
+import grit.stockIt.domain.member.entity.Member;
+import grit.stockIt.domain.stock.entity.Stock;
+import grit.stockIt.domain.stock.service.StockDetailService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import reactor.core.publisher.Mono;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("AssetService - HoldingItem 손익 필드 테스트")
+class AssetServiceHoldingItemTest {
+
+    @Mock private AccountRepository accountRepository;
+    @Mock private AccountStockRepository accountStockRepository;
+    @Mock private StockDetailService stockDetailService;
+
+    @InjectMocks private AssetService assetService;
+
+    private Member member;
+    private Contest contest;
+    private Account account;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder()
+                .memberId(1L)
+                .name("테스터")
+                .email("test@test.com")
+                .provider(AuthProvider.LOCAL)
+                .build();
+
+        contest = Contest.builder()
+                .contestId(1L)
+                .contestName("테스트 대회")
+                .seedMoney(10_000_000L)
+                .commissionRate(BigDecimal.ZERO)
+                .startDate(java.time.LocalDateTime.now())
+                .build();
+
+        account = Account.builder()
+                .accountId(1L)
+                .member(member)
+                .contest(contest)
+                .accountName("테스트 계좌")
+                .cash(new BigDecimal("5000000"))
+                .isDefault(true)
+                .build();
+
+        // SecurityContext 설정
+        var auth = new UsernamePasswordAuthenticationToken("test@test.com", null, List.of());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    private Stock createStock(String code, String name) {
+        return Stock.builder()
+                .code(code)
+                .name(name)
+                .marketType("KOSPI")
+                .build();
+    }
+
+    private AccountStock createAccountStock(Account account, Stock stock, int quantity, BigDecimal avgPrice) {
+        return AccountStock.create(account, stock, quantity, avgPrice);
+    }
+
+    // ==================== 테스트 1: 기본 손익 계산 (이익) ====================
+
+    @Test
+    @DisplayName("1. 주가 상승 시 양수 손익 및 수익률 계산")
+    void test_profitWhenPriceUp() {
+        // given: 70,000원에 10주 매수 → 현재가 72,000원
+        Stock stock = createStock("005930", "삼성전자");
+        AccountStock as = createAccountStock(account, stock, 10, new BigDecimal("70000"));
+
+        when(accountRepository.findById(1L)).thenReturn(Optional.of(account));
+        when(accountStockRepository.findByAccountIdWithStock(1L)).thenReturn(List.of(as));
+        when(stockDetailService.getCurrentPrice(anyString())).thenReturn(Mono.just(new BigDecimal("72000")));
+
+        // when
+        AssetResponse response = assetService.getAssets(1L);
+
+        // then
+        assertThat(response.holdings()).hasSize(1);
+        AssetResponse.HoldingItem item = response.holdings().get(0);
+
+        assertThat(item.averagePrice()).isEqualByComparingTo("70000");
+        assertThat(item.currentPrice()).isEqualByComparingTo("72000");
+        assertThat(item.quantity()).isEqualTo(10);
+        assertThat(item.totalValue()).isEqualByComparingTo("720000");                 // 72000 × 10
+        assertThat(item.investmentPrincipal()).isEqualByComparingTo("700000");        // 70000 × 10
+        assertThat(item.profitLossPerShare()).isEqualByComparingTo("2000");            // 72000 - 70000
+        assertThat(item.profitLossTotal()).isEqualByComparingTo("20000");              // 2000 × 10
+        assertThat(item.profitRate()).isEqualByComparingTo("2.86");                    // (20000/700000)*100
+    }
+
+    // ==================== 테스트 2: 손실 계산 ====================
+
+    @Test
+    @DisplayName("2. 주가 하락 시 음수 손익 및 수익률 계산")
+    void test_lossWhenPriceDown() {
+        // given: 50,000원에 20주 매수 → 현재가 45,000원
+        Stock stock = createStock("000660", "SK하이닉스");
+        AccountStock as = createAccountStock(account, stock, 20, new BigDecimal("50000"));
+
+        when(accountRepository.findById(1L)).thenReturn(Optional.of(account));
+        when(accountStockRepository.findByAccountIdWithStock(1L)).thenReturn(List.of(as));
+        when(stockDetailService.getCurrentPrice(anyString())).thenReturn(Mono.just(new BigDecimal("45000")));
+
+        // when
+        AssetResponse response = assetService.getAssets(1L);
+
+        // then
+        AssetResponse.HoldingItem item = response.holdings().get(0);
+
+        assertThat(item.profitLossPerShare()).isEqualByComparingTo("-5000");           // 45000 - 50000
+        assertThat(item.profitLossTotal()).isEqualByComparingTo("-100000");            // -5000 × 20
+        assertThat(item.profitRate()).isEqualByComparingTo("-10.00");                  // (-100000/1000000)*100
+        assertThat(item.investmentPrincipal()).isEqualByComparingTo("1000000");        // 50000 × 20
+    }
+
+    // ==================== 테스트 3: 손익 0 (가격 변동 없음) ====================
+
+    @Test
+    @DisplayName("3. 가격 변동 없으면 손익 0, 수익률 0")
+    void test_noProfitOrLoss() {
+        // given: 100,000원에 5주 매수 → 현재가 100,000원
+        Stock stock = createStock("035720", "카카오");
+        AccountStock as = createAccountStock(account, stock, 5, new BigDecimal("100000"));
+
+        when(accountRepository.findById(1L)).thenReturn(Optional.of(account));
+        when(accountStockRepository.findByAccountIdWithStock(1L)).thenReturn(List.of(as));
+        when(stockDetailService.getCurrentPrice(anyString())).thenReturn(Mono.just(new BigDecimal("100000")));
+
+        // when
+        AssetResponse response = assetService.getAssets(1L);
+
+        // then
+        AssetResponse.HoldingItem item = response.holdings().get(0);
+
+        assertThat(item.profitLossPerShare()).isEqualByComparingTo("0");
+        assertThat(item.profitLossTotal()).isEqualByComparingTo("0");
+        assertThat(item.profitRate()).isEqualByComparingTo("0.00");
+    }
+
+    // ==================== 테스트 4: 여러 종목 동시 보유 ====================
+
+    @Test
+    @DisplayName("4. 여러 종목 보유 시 각각의 손익 정확히 계산")
+    void test_multipleHoldings() {
+        // given
+        Stock stock1 = createStock("005930", "삼성전자");
+        Stock stock2 = createStock("000660", "SK하이닉스");
+        AccountStock as1 = createAccountStock(account, stock1, 10, new BigDecimal("70000"));  // +2,000
+        AccountStock as2 = createAccountStock(account, stock2, 5, new BigDecimal("120000"));  // -10,000
+
+        when(accountRepository.findById(1L)).thenReturn(Optional.of(account));
+        when(accountStockRepository.findByAccountIdWithStock(1L)).thenReturn(List.of(as1, as2));
+        when(stockDetailService.getCurrentPrice("005930")).thenReturn(Mono.just(new BigDecimal("72000")));
+        when(stockDetailService.getCurrentPrice("000660")).thenReturn(Mono.just(new BigDecimal("110000")));
+
+        // when
+        AssetResponse response = assetService.getAssets(1L);
+
+        // then
+        assertThat(response.holdings()).hasSize(2);
+
+        // 삼성전자: +2,000원/주
+        AssetResponse.HoldingItem samsung = response.holdings().stream()
+                .filter(h -> h.stockCode().equals("005930")).findFirst().orElseThrow();
+        assertThat(samsung.profitLossPerShare()).isEqualByComparingTo("2000");
+        assertThat(samsung.profitLossTotal()).isEqualByComparingTo("20000");
+
+        // SK하이닉스: -10,000원/주
+        AssetResponse.HoldingItem hynix = response.holdings().stream()
+                .filter(h -> h.stockCode().equals("000660")).findFirst().orElseThrow();
+        assertThat(hynix.profitLossPerShare()).isEqualByComparingTo("-10000");
+        assertThat(hynix.profitLossTotal()).isEqualByComparingTo("-50000");
+
+        // 총 자산: 현금 5,000,000 + 삼성 720,000 + SK 550,000 = 6,270,000
+        assertThat(response.totalAssets()).isEqualByComparingTo("6270000");
+        assertThat(response.stockValue()).isEqualByComparingTo("1270000");
+    }
+
+    // ==================== 테스트 5: 보유 종목 없음 ====================
+
+    @Test
+    @DisplayName("5. 보유 종목 없을 때 빈 holdings, 총자산 = 현금")
+    void test_noHoldings() {
+        when(accountRepository.findById(1L)).thenReturn(Optional.of(account));
+        when(accountStockRepository.findByAccountIdWithStock(1L)).thenReturn(List.of());
+
+        // when
+        AssetResponse response = assetService.getAssets(1L);
+
+        // then
+        assertThat(response.holdings()).isEmpty();
+        assertThat(response.totalAssets()).isEqualByComparingTo("5000000");
+        assertThat(response.cash()).isEqualByComparingTo("5000000");
+        assertThat(response.stockValue()).isEqualByComparingTo("0");
+    }
+
+    // ==================== 테스트 6: 소수점 정밀도 테스트 ====================
+
+    @Test
+    @DisplayName("6. 소수점 수익률 정밀도 확인 (반올림)")
+    void test_precisionRounding() {
+        // given: 33,333원에 3주 매수 → 현재가 34,000원
+        // profitLossPerShare = 667, total = 2001
+        // investmentPrincipal = 99999
+        // profitRate = (2001 / 99999) * 100 = 2.0010... → 2.00
+        Stock stock = createStock("TEST01", "테스트종목");
+        AccountStock as = createAccountStock(account, stock, 3, new BigDecimal("33333"));
+
+        when(accountRepository.findById(1L)).thenReturn(Optional.of(account));
+        when(accountStockRepository.findByAccountIdWithStock(1L)).thenReturn(List.of(as));
+        when(stockDetailService.getCurrentPrice(anyString())).thenReturn(Mono.just(new BigDecimal("34000")));
+
+        // when
+        AssetResponse response = assetService.getAssets(1L);
+
+        // then
+        AssetResponse.HoldingItem item = response.holdings().get(0);
+        assertThat(item.profitLossPerShare()).isEqualByComparingTo("667");
+        assertThat(item.profitLossTotal()).isEqualByComparingTo("2001");
+        // (2001 / 99999) * 100 = 2.001... → scale 4 → 2.0010 → *100 → 200.10 → ...
+        // Actually: 2001/99999 = 0.020010... → HALF_UP at scale 4 = 0.0200 → *100 = 2.00
+        assertThat(item.profitRate()).isEqualByComparingTo("2.00");
+    }
+}

--- a/src/test/java/grit/stockIt/domain/ranking/service/MemberPortfolioCrossViewTest.java
+++ b/src/test/java/grit/stockIt/domain/ranking/service/MemberPortfolioCrossViewTest.java
@@ -1,0 +1,315 @@
+package grit.stockIt.domain.ranking.service;
+
+import grit.stockIt.domain.account.entity.Account;
+import grit.stockIt.domain.account.entity.AccountStock;
+import grit.stockIt.domain.account.repository.AccountRepository;
+import grit.stockIt.domain.account.repository.AccountStockRepository;
+import grit.stockIt.domain.contest.entity.Contest;
+import grit.stockIt.domain.contest.repository.ContestRepository;
+import grit.stockIt.domain.matching.repository.RedisMarketDataRepository;
+import grit.stockIt.domain.member.entity.AuthProvider;
+import grit.stockIt.domain.member.entity.Member;
+import grit.stockIt.domain.mission.service.MissionService;
+import grit.stockIt.domain.ranking.dto.MemberPortfolioResponse;
+import grit.stockIt.domain.stock.entity.Stock;
+import grit.stockIt.domain.stock.service.StockDetailService;
+import grit.stockIt.global.exception.ForbiddenException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.core.env.Environment;
+import reactor.core.publisher.Mono;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+/**
+ * 4명의 대회 참가자(A, B, C, D)가 서로의 포트폴리오를 조회하는 통합 시나리오 테스트
+ *
+ * - 사용자 A: 삼성전자 100만원 보유
+ * - 사용자 B: SK하이닉스 100만원 보유
+ * - 사용자 C: 삼성전자 30만원 + SK하이닉스 30만원 + 현금 40만원
+ * - 사용자 D: 현금 100만원만 보유
+ * - 외부인 E: 대회에 참가하지 않은 사용자
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("대회 참가자 간 포트폴리오 상호 조회 테스트")
+class MemberPortfolioCrossViewTest {
+
+    @Mock private AccountRepository accountRepository;
+    @Mock private AccountStockRepository accountStockRepository;
+    @Mock private ContestRepository contestRepository;
+    @Mock private MissionService missionService;
+    @Mock private RedisMarketDataRepository redisMarketDataRepository;
+    @Mock private StockDetailService stockDetailService;
+    @Mock private Environment environment;
+
+    @InjectMocks private RankingService rankingService;
+
+    private Contest contest;
+    private Member memberA, memberB, memberC, memberD, memberE;
+    private Account accountA, accountB, accountC, accountD;
+    private Stock samsung, hynix;
+
+    @BeforeEach
+    void setUp() {
+        // 대회 설정: 시드머니 100만원
+        contest = Contest.builder()
+                .contestId(1L)
+                .contestName("test")
+                .seedMoney(1_000_000L)
+                .commissionRate(BigDecimal.ZERO)
+                .startDate(LocalDateTime.now().minusDays(7))
+                .endDate(LocalDateTime.now().plusDays(23))
+                .build();
+
+        // 종목 설정
+        samsung = Stock.builder().code("005930").name("삼성전자").marketType("KOSPI").build();
+        hynix = Stock.builder().code("000660").name("SK하이닉스").marketType("KOSPI").build();
+
+        // 4명의 회원
+        memberA = Member.builder().memberId(1L).name("사용자A").email("a@test.com").provider(AuthProvider.LOCAL).build();
+        memberB = Member.builder().memberId(2L).name("사용자B").email("b@test.com").provider(AuthProvider.LOCAL).build();
+        memberC = Member.builder().memberId(3L).name("사용자C").email("c@test.com").provider(AuthProvider.LOCAL).build();
+        memberD = Member.builder().memberId(4L).name("사용자D").email("d@test.com").provider(AuthProvider.LOCAL).build();
+        memberE = Member.builder().memberId(5L).name("외부인E").email("e@test.com").provider(AuthProvider.LOCAL).build();
+
+        // A: 삼성전자 100만원 (현금 0)
+        accountA = Account.builder().accountId(10L).member(memberA).contest(contest)
+                .accountName("A계좌").cash(BigDecimal.ZERO).isDefault(false).build();
+        // B: SK하이닉스 100만원 (현금 0)
+        accountB = Account.builder().accountId(20L).member(memberB).contest(contest)
+                .accountName("B계좌").cash(BigDecimal.ZERO).isDefault(false).build();
+        // C: 삼성전자 30만원 + SK하이닉스 30만원 + 현금 40만원
+        accountC = Account.builder().accountId(30L).member(memberC).contest(contest)
+                .accountName("C계좌").cash(new BigDecimal("400000")).isDefault(false).build();
+        // D: 현금 100만원만
+        accountD = Account.builder().accountId(40L).member(memberD).contest(contest)
+                .accountName("D계좌").cash(new BigDecimal("1000000")).isDefault(false).build();
+
+        // 공통 Mock
+        when(contestRepository.findById(1L)).thenReturn(Optional.of(contest));
+        when(accountRepository.findByContest(contest)).thenReturn(List.of(accountA, accountB, accountC, accountD));
+
+        when(accountRepository.findByMemberIdAndContestId(1L, 1L)).thenReturn(Optional.of(accountA));
+        when(accountRepository.findByMemberIdAndContestId(2L, 1L)).thenReturn(Optional.of(accountB));
+        when(accountRepository.findByMemberIdAndContestId(3L, 1L)).thenReturn(Optional.of(accountC));
+        when(accountRepository.findByMemberIdAndContestId(4L, 1L)).thenReturn(Optional.of(accountD));
+
+        // 보유 종목 설정
+        // A: 삼성전자 10주 × 100,000원 = 1,000,000원
+        AccountStock asA = AccountStock.create(accountA, samsung, 10, new BigDecimal("100000"));
+        when(accountStockRepository.findByAccountIdWithStock(10L)).thenReturn(List.of(asA));
+
+        // B: SK하이닉스 5주 × 200,000원 = 1,000,000원
+        AccountStock asB = AccountStock.create(accountB, hynix, 5, new BigDecimal("200000"));
+        when(accountStockRepository.findByAccountIdWithStock(20L)).thenReturn(List.of(asB));
+
+        // C: 삼성전자 3주 × 100,000원 = 300,000원 + SK하이닉스 1.5주(→2주) × 150,000원 = 300,000원
+        AccountStock asC1 = AccountStock.create(accountC, samsung, 3, new BigDecimal("100000"));
+        AccountStock asC2 = AccountStock.create(accountC, hynix, 2, new BigDecimal("150000"));
+        when(accountStockRepository.findByAccountIdWithStock(30L)).thenReturn(List.of(asC1, asC2));
+
+        // D: 종목 없음
+        when(accountStockRepository.findByAccountIdWithStock(40L)).thenReturn(List.of());
+
+        // 현재가 (매입가와 동일하게 설정하여 손익 검증 단순화)
+        when(redisMarketDataRepository.getLastPrice(anyString())).thenReturn(Optional.empty());
+        when(stockDetailService.getCurrentPrice("005930")).thenReturn(Mono.just(new BigDecimal("100000")));
+        when(stockDetailService.getCurrentPrice("000660")).thenReturn(Mono.just(new BigDecimal("200000")));
+    }
+
+    // ==================== 테스트 1: A가 B의 포트폴리오 조회 ====================
+
+    @Test
+    @DisplayName("1. 사용자A → 사용자B 포트폴리오 조회 (SK하이닉스 100%)")
+    void test_A_views_B() {
+        MemberPortfolioResponse response = rankingService.getMemberPortfolio(1L, 2L, "a@test.com");
+
+        assertThat(response.memberId()).isEqualTo(2L);
+        assertThat(response.nickname()).isEqualTo("사용자B");
+        assertThat(response.cash()).isEqualByComparingTo("0");
+        assertThat(response.cashPercent()).isEqualByComparingTo("0.00");
+        assertThat(response.totalAssets()).isEqualByComparingTo("1000000");
+        assertThat(response.holdings()).hasSize(1);
+
+        MemberPortfolioResponse.PortfolioItem item = response.holdings().get(0);
+        assertThat(item.stockName()).isEqualTo("SK하이닉스");
+        assertThat(item.percent()).isEqualByComparingTo("100.00");
+        assertThat(item.quantity()).isEqualTo(5);
+        assertThat(item.averagePrice()).isEqualByComparingTo("200000");
+    }
+
+    // ==================== 테스트 2: B가 A의 포트폴리오 조회 ====================
+
+    @Test
+    @DisplayName("2. 사용자B → 사용자A 포트폴리오 조회 (삼성전자 100%)")
+    void test_B_views_A() {
+        MemberPortfolioResponse response = rankingService.getMemberPortfolio(1L, 1L, "b@test.com");
+
+        assertThat(response.memberId()).isEqualTo(1L);
+        assertThat(response.nickname()).isEqualTo("사용자A");
+        assertThat(response.cash()).isEqualByComparingTo("0");
+        assertThat(response.cashPercent()).isEqualByComparingTo("0.00");
+        assertThat(response.totalAssets()).isEqualByComparingTo("1000000");
+        assertThat(response.holdings()).hasSize(1);
+
+        MemberPortfolioResponse.PortfolioItem item = response.holdings().get(0);
+        assertThat(item.stockName()).isEqualTo("삼성전자");
+        assertThat(item.percent()).isEqualByComparingTo("100.00");
+        assertThat(item.quantity()).isEqualTo(10);
+        assertThat(item.averagePrice()).isEqualByComparingTo("100000");
+    }
+
+    // ==================== 테스트 3: C가 D의 포트폴리오 조회 (현금 100%) ====================
+
+    @Test
+    @DisplayName("3. 사용자C → 사용자D 포트폴리오 조회 (현금만 100%)")
+    void test_C_views_D() {
+        MemberPortfolioResponse response = rankingService.getMemberPortfolio(1L, 4L, "c@test.com");
+
+        assertThat(response.memberId()).isEqualTo(4L);
+        assertThat(response.nickname()).isEqualTo("사용자D");
+        assertThat(response.cash()).isEqualByComparingTo("1000000");
+        assertThat(response.cashPercent()).isEqualByComparingTo("100.00");
+        assertThat(response.stockValue()).isEqualByComparingTo("0");
+        assertThat(response.holdings()).isEmpty();
+        assertThat(response.returnRate()).isEqualByComparingTo("0.00");
+    }
+
+    // ==================== 테스트 4: D가 C의 포트폴리오 조회 (혼합 포트폴리오) ====================
+
+    @Test
+    @DisplayName("4. 사용자D → 사용자C 포트폴리오 조회 (삼성 30% + 하이닉스 40% + 현금 40%)")
+    void test_D_views_C() {
+        MemberPortfolioResponse response = rankingService.getMemberPortfolio(1L, 3L, "d@test.com");
+
+        assertThat(response.memberId()).isEqualTo(3L);
+        assertThat(response.nickname()).isEqualTo("사용자C");
+
+        // 총자산: 현금 400,000 + 삼성 300,000 + SK 400,000 = 1,100,000
+        assertThat(response.totalAssets()).isEqualByComparingTo("1100000");
+        assertThat(response.cash()).isEqualByComparingTo("400000");
+        assertThat(response.stockValue()).isEqualByComparingTo("700000");
+
+        // 현금 비중: 400,000 / 1,100,000 * 100 = 36.36%
+        assertThat(response.cashPercent()).isEqualByComparingTo("36.36");
+
+        // 수익률: (1,100,000 - 1,000,000) / 1,000,000 * 100 = 10.00%
+        assertThat(response.returnRate()).isEqualByComparingTo("10.00");
+
+        assertThat(response.holdings()).hasSize(2);
+
+        // 평가액 내림차순 정렬: SK하이닉스(400,000) > 삼성전자(300,000)
+        MemberPortfolioResponse.PortfolioItem first = response.holdings().get(0);
+        assertThat(first.stockName()).isEqualTo("SK하이닉스");
+        assertThat(first.totalValue()).isEqualByComparingTo("400000");
+        // SK하이닉스 비중: 400,000 / 1,100,000 * 100 = 36.36%
+        assertThat(first.percent()).isEqualByComparingTo("36.36");
+
+        MemberPortfolioResponse.PortfolioItem second = response.holdings().get(1);
+        assertThat(second.stockName()).isEqualTo("삼성전자");
+        assertThat(second.totalValue()).isEqualByComparingTo("300000");
+        // 삼성전자 비중: 300,000 / 1,100,000 * 100 = 27.27%
+        assertThat(second.percent()).isEqualByComparingTo("27.27");
+
+        // 비중 합계 확인: 36.36 + 36.36 + 27.27 ≈ 99.99~100.01
+        BigDecimal totalPct = response.cashPercent()
+                .add(first.percent())
+                .add(second.percent());
+        assertThat(totalPct.doubleValue()).isBetween(99.90, 100.10);
+    }
+
+    // ==================== 테스트 5: A가 C의 포트폴리오 조회 (다른 조합) ====================
+
+    @Test
+    @DisplayName("5. 사용자A → 사용자C 포트폴리오 조회 (혼합 포트폴리오, 손익 포함)")
+    void test_A_views_C_withProfitLoss() {
+        // 현재가를 변경하여 손익 발생시킴
+        // 삼성전자: 매입가 100,000 → 현재가 110,000 (+10%)
+        // SK하이닉스: 매입가 150,000 → 현재가 200,000 (+33.33%)
+        // (기본 setUp에서 현재가: 삼성 100,000, SK 200,000)
+        // C의 삼성: 3주 × 100,000 = 300,000 (매입 300,000, 손익 0)
+        // C의 SK: 2주 × 200,000 = 400,000 (매입 300,000, 이익 100,000)
+
+        MemberPortfolioResponse response = rankingService.getMemberPortfolio(1L, 3L, "a@test.com");
+
+        assertThat(response.memberId()).isEqualTo(3L);
+
+        // SK하이닉스 손익 확인
+        MemberPortfolioResponse.PortfolioItem skItem = response.holdings().stream()
+                .filter(h -> h.stockCode().equals("000660")).findFirst().orElseThrow();
+        assertThat(skItem.averagePrice()).isEqualByComparingTo("150000");
+        assertThat(skItem.currentPrice()).isEqualByComparingTo("200000");
+        assertThat(skItem.profitLossPerShare()).isEqualByComparingTo("50000");
+        assertThat(skItem.profitLossTotal()).isEqualByComparingTo("100000");  // 50,000 × 2
+        assertThat(skItem.profitRate()).isEqualByComparingTo("33.33");        // 100,000/300,000*100
+
+        // 삼성전자 손익 확인 (매입가 = 현재가 → 손익 0)
+        MemberPortfolioResponse.PortfolioItem samsungItem = response.holdings().stream()
+                .filter(h -> h.stockCode().equals("005930")).findFirst().orElseThrow();
+        assertThat(samsungItem.profitLossPerShare()).isEqualByComparingTo("0");
+        assertThat(samsungItem.profitLossTotal()).isEqualByComparingTo("0");
+        assertThat(samsungItem.profitRate()).isEqualByComparingTo("0.00");
+    }
+
+    // ==================== 테스트 6: 외부인 E가 대회 참가자 조회 시 403 ====================
+
+    @Test
+    @DisplayName("6. 대회 미참가자(외부인E)가 참가자A의 포트폴리오 조회 시 ForbiddenException")
+    void test_outsider_E_blocked() {
+        assertThatThrownBy(() ->
+                rankingService.getMemberPortfolio(1L, 1L, "e@test.com")
+        ).isInstanceOf(ForbiddenException.class)
+                .hasMessageContaining("같은 대회 참가자만");
+    }
+
+    // ==================== 테스트 7: 모든 참가자가 서로 전부 조회 가능 검증 ====================
+
+    @Test
+    @DisplayName("7. 4명 참가자 모두가 서로의 포트폴리오를 조회 가능 (12가지 조합)")
+    void test_allParticipantsCanViewEachOther() {
+        String[] emails = {"a@test.com", "b@test.com", "c@test.com", "d@test.com"};
+        Long[] memberIds = {1L, 2L, 3L, 4L};
+
+        int successCount = 0;
+
+        for (String requesterEmail : emails) {
+            for (Long targetId : memberIds) {
+                MemberPortfolioResponse response = rankingService.getMemberPortfolio(1L, targetId, requesterEmail);
+
+                // 기본 검증: 응답 존재, memberId 일치
+                assertThat(response).isNotNull();
+                assertThat(response.memberId()).isEqualTo(targetId);
+                assertThat(response.totalAssets()).isNotNull();
+                assertThat(response.cashPercent()).isNotNull();
+
+                // 비중 합계 검증
+                BigDecimal totalPct = response.cashPercent();
+                for (MemberPortfolioResponse.PortfolioItem item : response.holdings()) {
+                    totalPct = totalPct.add(item.percent());
+                }
+                assertThat(totalPct.doubleValue()).isBetween(99.90, 100.10);
+
+                successCount++;
+            }
+        }
+
+        // 4명 × 4명 = 16 조합 (자기 자신 포함)
+        assertThat(successCount).isEqualTo(16);
+    }
+}

--- a/src/test/java/grit/stockIt/domain/ranking/service/MemberPortfolioTest.java
+++ b/src/test/java/grit/stockIt/domain/ranking/service/MemberPortfolioTest.java
@@ -1,0 +1,322 @@
+package grit.stockIt.domain.ranking.service;
+
+import grit.stockIt.domain.account.entity.Account;
+import grit.stockIt.domain.account.entity.AccountStock;
+import grit.stockIt.domain.account.repository.AccountRepository;
+import grit.stockIt.domain.account.repository.AccountStockRepository;
+import grit.stockIt.domain.contest.entity.Contest;
+import grit.stockIt.domain.contest.repository.ContestRepository;
+import grit.stockIt.domain.matching.repository.RedisMarketDataRepository;
+import grit.stockIt.domain.member.entity.AuthProvider;
+import grit.stockIt.domain.member.entity.Member;
+import grit.stockIt.domain.mission.service.MissionService;
+import grit.stockIt.domain.ranking.dto.MemberPortfolioResponse;
+import grit.stockIt.domain.stock.entity.Stock;
+import grit.stockIt.domain.stock.service.StockDetailService;
+import grit.stockIt.global.exception.ForbiddenException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.core.env.Environment;
+import reactor.core.publisher.Mono;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("RankingService - 대회 참가자 포트폴리오 조회 테스트")
+class MemberPortfolioTest {
+
+    @Mock private AccountRepository accountRepository;
+    @Mock private AccountStockRepository accountStockRepository;
+    @Mock private ContestRepository contestRepository;
+    @Mock private MissionService missionService;
+    @Mock private RedisMarketDataRepository redisMarketDataRepository;
+    @Mock private StockDetailService stockDetailService;
+    @Mock private Environment environment;
+
+    @InjectMocks private RankingService rankingService;
+
+    private Contest contest;
+    private Member requester;
+    private Member target;
+    private Account requesterAccount;
+    private Account targetAccount;
+
+    @BeforeEach
+    void setUp() {
+        contest = Contest.builder()
+                .contestId(1L)
+                .contestName("2026 모의투자 대회")
+                .seedMoney(10_000_000L)
+                .commissionRate(BigDecimal.ZERO)
+                .startDate(LocalDateTime.now().minusDays(7))
+                .endDate(LocalDateTime.now().plusDays(23))
+                .build();
+
+        requester = Member.builder()
+                .memberId(1L)
+                .name("요청자")
+                .email("requester@test.com")
+                .provider(AuthProvider.LOCAL)
+                .build();
+
+        target = Member.builder()
+                .memberId(2L)
+                .name("대상자")
+                .email("target@test.com")
+                .provider(AuthProvider.LOCAL)
+                .profileImage("https://example.com/profile.jpg")
+                .build();
+
+        requesterAccount = Account.builder()
+                .accountId(10L)
+                .member(requester)
+                .contest(contest)
+                .accountName("요청자 대회 계좌")
+                .cash(new BigDecimal("5000000"))
+                .isDefault(false)
+                .build();
+
+        targetAccount = Account.builder()
+                .accountId(20L)
+                .member(target)
+                .contest(contest)
+                .accountName("대상자 대회 계좌")
+                .cash(new BigDecimal("3000000"))
+                .isDefault(false)
+                .build();
+
+        // 공통 Mock 설정
+        when(contestRepository.findById(1L)).thenReturn(Optional.of(contest));
+        when(accountRepository.findByContest(contest)).thenReturn(List.of(requesterAccount, targetAccount));
+        when(accountRepository.findByMemberIdAndContestId(2L, 1L)).thenReturn(Optional.of(targetAccount));
+
+        // Redis 캐시 미스 → KIS API 호출하도록 설정
+        when(redisMarketDataRepository.getLastPrice(anyString())).thenReturn(Optional.empty());
+    }
+
+    private Stock createStock(String code, String name) {
+        return Stock.builder()
+                .code(code)
+                .name(name)
+                .marketType("KOSPI")
+                .build();
+    }
+
+    // ==================== 테스트 1: 정상 포트폴리오 조회 (종목 보유) ====================
+
+    @Test
+    @DisplayName("1. 같은 대회 참가자가 다른 참가자의 포트폴리오를 정상 조회")
+    void test_viewOtherParticipantPortfolio() {
+        // given: 대상자가 삼성전자 10주(평단가 70,000) 보유
+        Stock samsung = createStock("005930", "삼성전자");
+        AccountStock as = AccountStock.create(targetAccount, samsung, 10, new BigDecimal("70000"));
+
+        when(accountStockRepository.findByAccountIdWithStock(20L)).thenReturn(List.of(as));
+        when(stockDetailService.getCurrentPrice("005930")).thenReturn(Mono.just(new BigDecimal("75000")));
+
+        // when
+        MemberPortfolioResponse response = rankingService.getMemberPortfolio(1L, 2L, "requester@test.com");
+
+        // then
+        assertThat(response.memberId()).isEqualTo(2L);
+        assertThat(response.nickname()).isEqualTo("대상자");
+        assertThat(response.profileImage()).isEqualTo("https://example.com/profile.jpg");
+        assertThat(response.cash()).isEqualByComparingTo("3000000");
+        assertThat(response.holdings()).hasSize(1);
+
+        // 총자산: 현금 3,000,000 + 삼성 750,000 = 3,750,000
+        assertThat(response.totalAssets()).isEqualByComparingTo("3750000");
+        assertThat(response.stockValue()).isEqualByComparingTo("750000");
+
+        // 현금 비중: 3,000,000 / 3,750,000 * 100 = 80.00%
+        assertThat(response.cashPercent()).isEqualByComparingTo("80.00");
+
+        // 수익률: (3,750,000 - 10,000,000) / 10,000,000 * 100 = -62.50%
+        assertThat(response.returnRate()).isEqualByComparingTo("-62.50");
+
+        // 종목 상세
+        MemberPortfolioResponse.PortfolioItem item = response.holdings().get(0);
+        assertThat(item.stockCode()).isEqualTo("005930");
+        assertThat(item.stockName()).isEqualTo("삼성전자");
+        assertThat(item.quantity()).isEqualTo(10);
+        assertThat(item.averagePrice()).isEqualByComparingTo("70000");
+        assertThat(item.currentPrice()).isEqualByComparingTo("75000");
+        assertThat(item.profitLossPerShare()).isEqualByComparingTo("5000");
+        assertThat(item.profitLossTotal()).isEqualByComparingTo("50000");
+        assertThat(item.profitRate()).isEqualByComparingTo("7.14");  // 50000/700000*100
+
+        // 종목 비중: 750,000 / 3,750,000 * 100 = 20.00%
+        assertThat(item.percent()).isEqualByComparingTo("20.00");
+    }
+
+    // ==================== 테스트 2: 다른 대회 참가자가 조회 시 403 ====================
+
+    @Test
+    @DisplayName("2. 같은 대회에 참가하지 않은 사용자가 조회하면 ForbiddenException")
+    void test_forbiddenWhenNotInSameContest() {
+        // given: outsider@test.com은 대회에 참가하지 않음
+        // accountRepository.findByContest는 requester, target만 반환
+
+        // when & then
+        assertThatThrownBy(() ->
+                rankingService.getMemberPortfolio(1L, 2L, "outsider@test.com")
+        ).isInstanceOf(ForbiddenException.class)
+                .hasMessageContaining("같은 대회 참가자만");
+    }
+
+    // ==================== 테스트 3: 존재하지 않는 대회 조회 ====================
+
+    @Test
+    @DisplayName("3. 존재하지 않는 대회 ID로 조회 시 예외")
+    void test_contestNotFound() {
+        when(contestRepository.findById(999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+                rankingService.getMemberPortfolio(999L, 2L, "requester@test.com")
+        ).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("대회를 찾을 수 없습니다");
+    }
+
+    // ==================== 테스트 4: 대상 회원이 대회에 없는 경우 ====================
+
+    @Test
+    @DisplayName("4. 대상 회원이 해당 대회에 참가하지 않은 경우 예외")
+    void test_targetMemberNotInContest() {
+        when(accountRepository.findByMemberIdAndContestId(999L, 1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+                rankingService.getMemberPortfolio(1L, 999L, "requester@test.com")
+        ).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("대회 계좌를 찾을 수 없습니다");
+    }
+
+    // ==================== 테스트 5: 보유 종목 없이 현금만 있는 참가자 ====================
+
+    @Test
+    @DisplayName("5. 보유 종목 없이 현금만 보유한 참가자 포트폴리오 조회")
+    void test_cashOnlyPortfolio() {
+        // given: 대상자가 종목 없이 현금 3,000,000만 보유
+        when(accountStockRepository.findByAccountIdWithStock(20L)).thenReturn(List.of());
+
+        // when
+        MemberPortfolioResponse response = rankingService.getMemberPortfolio(1L, 2L, "requester@test.com");
+
+        // then
+        assertThat(response.holdings()).isEmpty();
+        assertThat(response.totalAssets()).isEqualByComparingTo("3000000");
+        assertThat(response.cash()).isEqualByComparingTo("3000000");
+        assertThat(response.cashPercent()).isEqualByComparingTo("100.00");
+        assertThat(response.stockValue()).isEqualByComparingTo("0");
+        assertThat(response.returnRate()).isEqualByComparingTo("-70.00");  // (3M - 10M) / 10M * 100
+    }
+
+    // ==================== 테스트 6: 여러 종목 보유 시 비중 합계 검증 ====================
+
+    @Test
+    @DisplayName("6. 여러 종목 보유 시 현금 + 종목 비중 합계가 약 100%")
+    void test_multipleHoldingsPercentSum() {
+        // given
+        Stock stock1 = createStock("005930", "삼성전자");
+        Stock stock2 = createStock("000660", "SK하이닉스");
+        Stock stock3 = createStock("035720", "카카오");
+
+        AccountStock as1 = AccountStock.create(targetAccount, stock1, 10, new BigDecimal("70000"));
+        AccountStock as2 = AccountStock.create(targetAccount, stock2, 5, new BigDecimal("150000"));
+        AccountStock as3 = AccountStock.create(targetAccount, stock3, 20, new BigDecimal("50000"));
+
+        when(accountStockRepository.findByAccountIdWithStock(20L)).thenReturn(List.of(as1, as2, as3));
+        when(stockDetailService.getCurrentPrice("005930")).thenReturn(Mono.just(new BigDecimal("72000")));
+        when(stockDetailService.getCurrentPrice("000660")).thenReturn(Mono.just(new BigDecimal("155000")));
+        when(stockDetailService.getCurrentPrice("035720")).thenReturn(Mono.just(new BigDecimal("48000")));
+
+        // when
+        MemberPortfolioResponse response = rankingService.getMemberPortfolio(1L, 2L, "requester@test.com");
+
+        // then
+        assertThat(response.holdings()).hasSize(3);
+
+        // 비중 합계 검증 (현금 비중 + 종목 비중 합 ≈ 100%)
+        BigDecimal totalPercent = response.cashPercent();
+        for (MemberPortfolioResponse.PortfolioItem item : response.holdings()) {
+            totalPercent = totalPercent.add(item.percent());
+        }
+        // 반올림으로 인해 99.98~100.02 범위
+        assertThat(totalPercent.doubleValue()).isBetween(99.90, 100.10);
+
+        // 총자산: 현금 3,000,000 + 삼성 720,000 + SK 775,000 + 카카오 960,000
+        BigDecimal expectedTotal = new BigDecimal("3000000")
+                .add(new BigDecimal("720000"))
+                .add(new BigDecimal("775000"))
+                .add(new BigDecimal("960000"));
+        assertThat(response.totalAssets()).isEqualByComparingTo(expectedTotal);
+    }
+
+    // ==================== 테스트 7: 평가액 내림차순 정렬 검증 ====================
+
+    @Test
+    @DisplayName("7. 종목이 평가액 내림차순으로 정렬되는지 검증")
+    void test_holdingsSortedByValueDesc() {
+        // given: 3종목 평가액이 다른 경우
+        Stock stock1 = createStock("005930", "삼성전자");    // 10 × 72000 = 720,000 (2위)
+        Stock stock2 = createStock("000660", "SK하이닉스");   // 5 × 155000 = 775,000 (1위)
+        Stock stock3 = createStock("035720", "카카오");       // 3 × 48000  = 144,000 (3위)
+
+        AccountStock as1 = AccountStock.create(targetAccount, stock1, 10, new BigDecimal("70000"));
+        AccountStock as2 = AccountStock.create(targetAccount, stock2, 5, new BigDecimal("150000"));
+        AccountStock as3 = AccountStock.create(targetAccount, stock3, 3, new BigDecimal("50000"));
+
+        when(accountStockRepository.findByAccountIdWithStock(20L)).thenReturn(List.of(as1, as2, as3));
+        when(stockDetailService.getCurrentPrice("005930")).thenReturn(Mono.just(new BigDecimal("72000")));
+        when(stockDetailService.getCurrentPrice("000660")).thenReturn(Mono.just(new BigDecimal("155000")));
+        when(stockDetailService.getCurrentPrice("035720")).thenReturn(Mono.just(new BigDecimal("48000")));
+
+        // when
+        MemberPortfolioResponse response = rankingService.getMemberPortfolio(1L, 2L, "requester@test.com");
+
+        // then: SK하이닉스(775,000) > 삼성전자(720,000) > 카카오(144,000)
+        List<MemberPortfolioResponse.PortfolioItem> items = response.holdings();
+        assertThat(items.get(0).stockName()).isEqualTo("SK하이닉스");
+        assertThat(items.get(1).stockName()).isEqualTo("삼성전자");
+        assertThat(items.get(2).stockName()).isEqualTo("카카오");
+    }
+
+    // ==================== 테스트 8: 자기 자신 포트폴리오 조회 ====================
+
+    @Test
+    @DisplayName("8. 자기 자신의 포트폴리오도 이 API로 조회 가능")
+    void test_viewOwnPortfolio() {
+        // given: 요청자 = 대상자 (memberId = 1)
+        when(accountRepository.findByMemberIdAndContestId(1L, 1L)).thenReturn(Optional.of(requesterAccount));
+
+        Stock stock = createStock("005930", "삼성전자");
+        AccountStock as = AccountStock.create(requesterAccount, stock, 5, new BigDecimal("80000"));
+
+        when(accountStockRepository.findByAccountIdWithStock(10L)).thenReturn(List.of(as));
+        when(stockDetailService.getCurrentPrice("005930")).thenReturn(Mono.just(new BigDecimal("85000")));
+
+        // when
+        MemberPortfolioResponse response = rankingService.getMemberPortfolio(1L, 1L, "requester@test.com");
+
+        // then
+        assertThat(response.memberId()).isEqualTo(1L);
+        assertThat(response.nickname()).isEqualTo("요청자");
+        assertThat(response.holdings()).hasSize(1);
+        assertThat(response.holdings().get(0).profitLossPerShare()).isEqualByComparingTo("5000");
+    }
+}


### PR DESCRIPTION
## Summary

프론트엔드 요청 스펙(`PORTFOLIO_FEATURE_SPEC.md`)에 따라 포트폴리오 관련 API 2건 구현.

### 기능 A: 내 포트폴리오 손익 상세

`GET /api/accounts/{accountId}/assets` 응답의 `holdings` 배열에 다음 필드 추가 (하위 호환):
- `investment_principal`: 투자 원금 (수량 × 평단가)
- `profit_loss_per_share`: 1주당 손익 (현재가 - 평단가)
- `profit_loss_total`: 총 손익
- `profit_rate`: 수익률 (%)

### 기능 B: 대회 참가자 포트폴리오 조회

신규 엔드포인트: `GET /api/rankings/contest/{contestId}/members/{memberId}/portfolio`

- 같은 대회 참가자만 조회 가능 (미참가 시 403 Forbidden)
- 응답: 사용자 정보 + 자산 요약(현금 비중 포함) + 종목별 평가액/비중/손익
- `holdings`는 평가액 내림차순 정렬

## Test plan

- [x] `AssetServiceHoldingItemTest`: HoldingItem의 손익 필드 계산 검증
- [x] `MemberPortfolioTest`: 대회 참가자 포트폴리오 조회 기본 플로우
- [x] `MemberPortfolioCrossViewTest`: 같은 대회 다른 참가자 조회 권한 검증
- [ ] 프론트엔드 통합 테스트 (머지 후 배포 시)