### PR TITLE
fix: 테스트 스위트 복구 및 CI 테스트 활성화 (#191)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -45,8 +45,8 @@ jobs:
     - name: Make gradlew executable
       run: chmod +x gradlew
       
-    - name: Build application
-      run: ./gradlew build -x test
+    - name: Build and test application
+      run: ./gradlew build
       
   # CD: main 브랜치에서만 Docker 이미지 빌드 및 배포
   cd:

--- a/src/test/java/grit/stockIt/StockItApplicationTests.java
+++ b/src/test/java/grit/stockIt/StockItApplicationTests.java
@@ -1,10 +1,9 @@
 package grit.stockIt;
 
+import grit.stockIt.global.support.IntegrationTestSupport;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
-class StockItApplicationTests {
+class StockItApplicationTests extends IntegrationTestSupport {
 
 	@Test
 	void contextLoads() {

--- a/src/test/java/grit/stockIt/domain/matching/service/LimitOrderExecutionServiceTest.java
+++ b/src/test/java/grit/stockIt/domain/matching/service/LimitOrderExecutionServiceTest.java
@@ -20,6 +20,7 @@ import grit.stockIt.domain.order.repository.OrderHoldRepository;
 import grit.stockIt.domain.order.repository.OrderRepository;
 import grit.stockIt.domain.stock.entity.Stock;
 import grit.stockIt.global.websocket.manager.OrderSubscriptionCoordinator;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -83,6 +84,9 @@ class LimitOrderExecutionServiceTest {
 
     @Mock
     private ObjectMapper objectMapper;
+
+    @Mock
+    private EntityManager entityManager;
 
     @InjectMocks
     private LimitOrderExecutionService limitOrderExecutionService;

--- a/src/test/java/grit/stockIt/domain/stock/service/StockRankingServiceTest.java
+++ b/src/test/java/grit/stockIt/domain/stock/service/StockRankingServiceTest.java
@@ -3,6 +3,7 @@ package grit.stockIt.domain.stock.service;
 import grit.stockIt.domain.stock.dto.StockRankingDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -11,6 +12,13 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * 실제 KIS API와 종목 데이터가 있는 로컬 DB(local 프로필)가 필요한 수동 확인용 테스트.
+ * RUN_MANUAL_TESTS=true 환경변수로 명시적으로 실행할 때만 동작하고, CI에서는 자동으로 skip 된다.
+ * 실행 예: RUN_MANUAL_TESTS=true ./gradlew test --tests "StockRankingServiceTest"
+ */
+@EnabledIfEnvironmentVariable(named = "RUN_MANUAL_TESTS", matches = "true",
+        disabledReason = "로컬 DB + 실제 KIS API가 필요한 수동 확인용 테스트 (RUN_MANUAL_TESTS=true 로 실행)")
 @SpringBootTest
 @ActiveProfiles("local")
 class StockRankingServiceTest {

--- a/src/test/java/grit/stockIt/global/auth/KisTokenManagerTest.java
+++ b/src/test/java/grit/stockIt/global/auth/KisTokenManagerTest.java
@@ -1,41 +1,28 @@
 package grit.stockIt.global.auth;
 
-import org.junit.jupiter.api.BeforeEach;
+import grit.stockIt.global.support.IntegrationTestSupport;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.test.context.TestPropertySource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest
-@TestPropertySource(properties = {
-    "kis.api.appkey=${KIS_API_APPKEY:test_appkey}",
-    "kis.api.appsecret=${KIS_API_APPSECRET:test_appsecret}"
-})
-class KisTokenManagerTest {
+/**
+ * 실제 KIS API를 호출해 토큰 발급/캐싱을 검증하는 외부 연동 테스트.
+ * 실제 API 키가 환경변수(KIS_API_APPKEY)로 설정된 경우에만 실행되고,
+ * 그 외(CI 포함)에는 자동으로 skip 된다.
+ */
+@EnabledIfEnvironmentVariable(named = "KIS_API_APPKEY", matches = ".+",
+        disabledReason = "실제 KIS API 키(KIS_API_APPKEY)가 있을 때만 실행되는 외부 연동 테스트")
+class KisTokenManagerTest extends IntegrationTestSupport {
 
     @Autowired
     private KisTokenManager kisTokenManager;
 
     @Autowired
     private StringRedisTemplate redisTemplate; // Redis를 직접 확인하기 위해 주입
-
-    @BeforeEach
-    void setUp() {
-        // 환경변수 체크
-        String appkey = System.getenv("KIS_API_APPKEY");
-        String appsecret = System.getenv("KIS_API_APPSECRET");
-        
-        if (appkey == null || appkey.isEmpty() || appsecret == null || appsecret.isEmpty()) {
-            System.out.println("경고: 환경변수 KIS_API_APPKEY 또는 KIS_API_APPSECRET가 설정되지 않았습니다.");
-            System.out.println("테스트용 더미 값으로 실행됩니다.");
-        } else {
-            System.out.println("환경변수에서 실제 API 키를 사용합니다.");
-        }
-    }
 
     @Test
     @DisplayName("AccessToken을 성공적으로 발급받고 Redis에 저장한다")
@@ -44,24 +31,19 @@ class KisTokenManagerTest {
         redisTemplate.delete("kis:access_token");
 
         // 2. 토큰을 처음 요청한다 (이때 KIS 서버에 접속해야 함)
-        System.out.println("--- 1번째 요청 ---");
         String token1 = kisTokenManager.getAccessToken();
 
         // 3. 토큰이 null이 아니고 비어있지 않은지 확인
         assertThat(token1).isNotNull().isNotEmpty();
-        System.out.println("발급받은 토큰: " + token1);
 
         // 4. Redis에 정말 저장되었는지 확인
         String cachedToken = redisTemplate.opsForValue().get("kis:access_token");
         assertThat(cachedToken).isEqualTo(token1);
-        System.out.println("Redis에 저장된 토큰: " + cachedToken);
 
         // 5. 토큰을 다시 요청한다 (이때는 KIS 서버가 아닌 Redis에서 가져와야 함)
-        System.out.println("--- 2번째 요청 ---");
         String token2 = kisTokenManager.getAccessToken();
 
         // 6. 1번 토큰과 2번 토큰이 같은지 확인 (같아야 Redis 캐시가 동작한 것)
         assertThat(token2).isEqualTo(token1);
-        System.out.println("캐시에서 가져온 토큰: " + token2);
     }
 }

--- a/src/test/java/grit/stockIt/global/support/IntegrationTestSupport.java
+++ b/src/test/java/grit/stockIt/global/support/IntegrationTestSupport.java
@@ -1,0 +1,47 @@
+package grit.stockIt.global.support;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Testcontainers 기반 통합 테스트 공용 베이스 클래스.
+ * PostgreSQL/Redis 컨테이너를 자동으로 띄우므로 로컬 DB 없이 어디서든(CI 포함) 실행 가능하다.
+ * DB가 필요한 @SpringBootTest 는 이 클래스를 상속한다.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Testcontainers
+@TestPropertySource(properties = "spring.task.scheduling.enabled=false")
+public abstract class IntegrationTestSupport {
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>(DockerImageName.parse("postgres:15"))
+            .withDatabaseName("test_database")
+            .withUsername("test_user")
+            .withPassword("test_password")
+            .withReuse(true);
+
+    @Container
+    static final GenericContainer<?> REDIS = new GenericContainer<>(DockerImageName.parse("redis:7"))
+            .withExposedPorts(6379)
+            .withReuse(true);
+
+    @DynamicPropertySource
+    static void configureContainers(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+        registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+
+        registry.add("spring.data.redis.host", REDIS::getHost);
+        registry.add("spring.data.redis.port", REDIS::getFirstMappedPort);
+    }
+}


### PR DESCRIPTION
### 🚀 Summary

CI가 `./gradlew build -x test`로 테스트를 건너뛰는 동안 테스트 스위트가 방치되어 24개 중 15개가 실패하고 있었다. 실패 테스트를 전부 수리해 green으로 복구하고, CI에서 `-x test`를 제거해 브랜치 보호의 required check(`ci`)가 실제로 테스트 실패를 차단하도록 만든다.

---

### 📝 변경 사항

- `LimitOrderExecutionServiceTest`에 `@Mock EntityManager` 추가 — 프로덕션 코드에 `EntityManager` 의존성이 추가된 후 mock이 누락되어 발생하던 NPE 10건 복구
- `IntegrationTestSupport` 신설 — PostgreSQL 15 / Redis 7 Testcontainers를 자동으로 띄우는 공용 베이스 클래스. DB가 필요한 `@SpringBootTest`는 이 클래스를 상속하면 로컬 DB 없이 어디서든(CI 포함) 실행 가능
- `StockItApplicationTests`, `KisTokenManagerTest`를 `IntegrationTestSupport` 기반으로 전환 (localhost DB 의존 제거)
- `KisTokenManagerTest`는 실제 KIS API를 호출하므로 `@EnabledIfEnvironmentVariable(KIS_API_APPKEY)` — 실키가 있을 때만 실행, CI에서는 skip
- `StockRankingServiceTest`는 실 KIS API + 종목 데이터가 있는 로컬 DB가 필요한 수동 확인용 테스트 — `RUN_MANUAL_TESTS=true` 옵트인으로만 실행
- `ci-cd.yml`: `./gradlew build -x test` → `./gradlew build` — CI가 테스트를 실제로 실행

---

### 🏷️ 변경 유형

- [ ] ✨ 기능 (feat)
- [x] 🐛 버그 수정 (fix)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] 📑 문서 (docs)
- [x] 🧭 환경설정 / 인프라 (chore)
- [ ] ⚠️ Breaking change (기존 동작/API 변경)

---

### ✅ 테스트 / 검증 방법

- 로컬에서 CI와 동일 조건(KIS 키 없는 환경)으로 전체 실행: `env -u KIS_API_APPKEY ./gradlew build` → **BUILD SUCCESSFUL**
- 결과: 24개 중 통과 20 / 실패 0 / 스킵 4 (스킵은 외부 API·로컬 DB 의존 테스트의 의도된 동작)
- 이 PR의 `ci` 체크에서 테스트가 실제 실행되는지 확인 (before: 컴파일만 / after: 테스트 포함)

---

### 🖼️ 실행 결과 / 스크린샷

---

### 🔀 배포 / 마이그레이션 노트

없음 (테스트 코드와 CI 워크플로우만 변경, 프로덕션 코드 무변경)

---

### ☑️ 체크리스트

- [x] 셀프 리뷰를 완료했습니다
- [x] 코드 컨벤션(네이밍 / DTO / REST 경로)을 따랐습니다
- [x] 테스트를 추가/수정했고 통과합니다
- [ ] 필요한 문서(README / AGENTS / docs)를 갱신했습니다
- [x] 시크릿·민감 정보가 커밋에 포함되지 않았습니다

---

### 🎲 관련 이슈

close #191
