### PR TITLE
refactor: mission 도메인 테스트 가능성 리팩토링 + 도메인 결합 이벤트 전환

### DIFF
--- a/docs/mission-refactor-changes.md
+++ b/docs/mission-refactor-changes.md
@@ -1,0 +1,54 @@
+# mission 도메인 리팩토링 — 의도된 동작 변경 목록 및 버그 판정 요청
+
+브랜치: `refactor/mission-testability` (develop 7b6cf03 기반)
+근거 계획: ralplan 합의 계획(딥 인터뷰 스펙 `deep-interview-mission-testability-refactor.md` 기반)
+
+## 1. 의도된 동작 변경 목록 (AC7)
+
+> 원칙: 리팩토링 전후 관찰 가능한 동작(API 응답, DB 상태 변화, 발행 이벤트)은 동일하다.
+> 명백한 버그는 사용자 판정 후에만 별도 커밋으로 수정한다.
+
+| # | 지점(파일:라인) | 사용자 승인 근거 | 커밋 해시 |
+|---|----------------|-----------------|----------|
+| — | (없음) | 승인된 버그 수정 0건 — 프로덕션 동작 변경 없음 | — |
+
+### 참고: 테스트 인프라 변경 (프로덕션 동작 아님, 투명성 기록)
+
+| 지점 | 내용 | 커밋 |
+|------|------|------|
+| `IntegrationTestSupport` | `@Container` 확장 → 싱글턴 컨테이너 패턴(클래스별 컨테이너 재시작이 캐시된 컨텍스트를 깨는 결함 수정) | 8ce8198 |
+| `LimitOrderMatchingServiceConcurrencyTest` | 자체 `@Container`(동일 설정) → `IntegrationTestSupport` 상속(reuse 활성 시 공유 컨테이너 stop 충돌 제거) | f3ff07c |
+| (환경) `~/.testcontainers.properties` | `testcontainers.reuse.enable=true` 추가 — `withReuse(true)` 설계 의도 활성화 | 커밋 외(로컬 환경) |
+
+## 2. 버그 의심 지점 — 사용자 판정 요청
+
+> 아래 항목은 전부 **현재 동작 그대로 특성화 테스트로 고정**되어 있다(수정 안 함).
+> 수정을 승인하면 해당 특성화 테스트를 기대값 갱신(변경 사유 주석 포함)과 함께 별도 커밋으로 처리한다.
+
+| # | 지점 | 현재 동작 | 왜 의심스러운가 | 고정한 테스트 |
+|---|------|----------|----------------|--------------|
+| a | `MissionProgressService.updateMissionProgress` (구 MissionService L86~89) | AccountId가 null인 체결 이벤트도 경고 로그만 남기고 기본 계좌 검증 없이 집계 진행 | 보조 계좌 제외 로직을 우회하는 구멍 | MissionServiceIntegrationTest 4-1 |
+| b | `MissionTrackPolicy.isFirstMissionInTrack` (구 L906~910) | 미션 ID 201/301/401 리터럴 하드코딩 | 시드 데이터 변경 시 조용히 무너지는 결합(현재 캡슐화만 완료, 값 판정은 보류) | MissionTrackPolicyTest |
+| c | `MissionRewardService.checkLegendTier` (구 L158~) | 점수 3600 하드코딩으로 LEGEND 티어 판정 | 티어 테이블(getTierInfo의 15단계 if-else)과 이중 관리 | MissionQueryIntegrationTest 티어 3종 |
+| d | `MissionQueryService.getMissionProgressList` (구 L996) | 호출자 0건인 dead 공개 API(엔티티 List 반환) | 삭제 시 커버리지 분모 감소 + API 표면 축소. 프론트 사용 여부 확인 필요 | (이동만, 테스트 없음) |
+| e | `MissionController` L27 | 사용되지 않는 `MissionScheduler` 주입 | dead 의존 | — |
+| f | `MissionService.applyForBankruptcy` | 파산 신청 기준이 코드상 총자산 100만원 미만(경계 100만원 정확히는 거절), 칭호/스웨거 문구는 "5만원 미만" | 문서·코드 불일치 — 어느 쪽이 맞는지 판정 필요 | MissionQueryIntegrationTest 파산 3종 |
+| g | `LocalMemberService.signup` + `Member.name varchar(20)` | 이메일 로컬파트를 name으로 사용 → 로컬파트 20자 초과 이메일이면 가입 자체가 DataIntegrityViolationException으로 실패 | 실사용자 가입 실패 가능성 있는 잠재 프로덕션 버그 | (테스트 작성 중 실측, 픽스처는 회피) |
+| h | `MissionRewardService.resetMissionTrack` (구 L890) | ADVANCED 미션 완료 시 자기 자신 포함 트랙 전체를 reset+deactivate — COMPLETED 기록·진행도 즉시 소실(보상 현금은 지급됨), 완료 카운트(901) 미반영 | 완료 이력이 사라지는 것이 의도인지 불명확 | MissionServiceIntegrationTest 6 |
+| i | `MissionProgressService.processRankerAchievement` (구 L856) | 목표치 조회 없이 `setCurrentValue(10)` 하드코딩 | 미션 목표(10) 변경 시 어긋남 | MissionServiceIntegrationTest 8 |
+| j | `MissionQueryService.getMissionsByTrack` (구 L610~617) | 잘못된 track 문자열 → 예외 삼키고 빈 목록 반환(경고 로그만) | 클라이언트 오타가 조용히 빈 응답으로 위장 | MissionQueryIntegrationTest |
+
+## 3. 수용 기준 충족 요약 (AC1~AC10)
+
+| AC | 기준 | 증빙 |
+|----|------|------|
+| AC1 | 핵심 경로 통합 특성화 green | MissionServiceIntegrationTest 13 시나리오 (fe7f923, 0a87046) |
+| AC2 | 순수 계산 단위 특성화 green | Evaluator 51 / Calculator 30 / TrackPolicy 13 (2993f53에서 직접 호출 승격) |
+| AC3 | 리팩토링 후 동일 스위트 전부 green | 전체 159/0 (skip 3 = 기존 외부 연동 수동 게이트) |
+| AC4 | `./gradlew build` 통과 + 베이스라인 신규 0 | BUILD SUCCESSFUL ×2 연속, suppressions/archunit_store diff 0줄 |
+| AC5 | mission 라인 커버리지 ≥70% | 76.7% (553/721, JaCoCo XML) — 기준선 70.5%에서 상승 |
+| AC6 | 결과 클래스 단일 책임 | 6클래스 분해(199/282/274/235/92 + 순수 3), architect 리뷰 CLEAR/APPROVE ×3회 |
+| AC7 | 의도된 동작 변경 목록 | 본 문서 §1 (빈 목록) |
+| AC8 | API 응답 계약 무변경 | 조회 응답 값 특성화 18종 무수정 green, DTO 필드 무변경 |
+| AC9 | 타 도메인 mission 서비스 직접 주입 제거 | import 전수 감사: 서비스 1건(RankingService→MissionQueryService) + 허용 잔존 3건 정확 일치 |
+| AC10 | 이벤트 전환 전후 특성화 무수정 green | Phase D 구간 src/test diff 0줄, A-5 롤백 전파 포함 green |

--- a/docs/mission-refactor-changes.md
+++ b/docs/mission-refactor-changes.md
@@ -50,5 +50,5 @@
 | AC6 | 결과 클래스 단일 책임 | 6클래스 분해(199/282/274/235/92 + 순수 3), architect 리뷰 CLEAR/APPROVE ×3회 |
 | AC7 | 의도된 동작 변경 목록 | 본 문서 §1 (빈 목록) |
 | AC8 | API 응답 계약 무변경 | 조회 응답 값 특성화 18종 무수정 green, DTO 필드 무변경 |
-| AC9 | 타 도메인 mission 서비스 직접 주입 제거 | import 전수 감사: 서비스 1건(RankingService→MissionQueryService) + 허용 잔존 3건 정확 일치 |
+| AC9 | 타 도메인이 mission **쓰기** 서비스를 직접 주입하지 않음(커맨드 경로는 이벤트로 단절). **조회용 `MissionQueryService` 직접 주입 1건(RankingService→getTierInfo)은 의도적 잔존** — 값 반환 조회라 이벤트화 불가 | import 전수 감사: 쓰기 서비스 주입 0건, 조회 서비스 1건 + 허용 잔존 2건(Member.java의 mission.entity, RankingService의 mission.dto) 정확 일치 |
 | AC10 | 이벤트 전환 전후 특성화 무수정 green | Phase D 구간 src/test diff 0줄, A-5 롤백 전파 포함 green |

--- a/src/main/java/grit/stockIt/domain/auth/service/KakaoAuthService.java
+++ b/src/main/java/grit/stockIt/domain/auth/service/KakaoAuthService.java
@@ -9,11 +9,13 @@ import grit.stockIt.domain.auth.dto.KakaoUserInfoResponse;
 import grit.stockIt.domain.auth.entity.KakaoToken;
 import grit.stockIt.domain.member.entity.AuthProvider;
 import grit.stockIt.domain.member.entity.Member;
+import grit.stockIt.domain.member.event.MemberRegisteredEvent;
 import grit.stockIt.domain.member.repository.MemberRepository;
 import grit.stockIt.global.jwt.JwtService;
 import grit.stockIt.global.jwt.JwtToken;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
@@ -22,7 +24,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import grit.stockIt.domain.mission.service.MissionService;
 
 @Slf4j
 @Service
@@ -34,7 +35,7 @@ public class KakaoAuthService {
     private final MemberRepository memberRepository;
     private final JwtService jwtService;
     private final AccountService accountService;
-    private final MissionService missionService;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 카카오 로그인 (비동기 처리)
@@ -105,8 +106,8 @@ public class KakaoAuthService {
             // 디폴트 계좌 생성 (회원당 1개 보장)
             accountService.createDefaultAccountForMember(savedMember);
 
-            // 미션 초기화
-            missionService.initializeMissionsForNewMember(savedMember);
+            // 미션 초기화 (동기 이벤트 — 리스너 예외는 그대로 전파되어 가입 전체 롤백)
+            eventPublisher.publishEvent(new MemberRegisteredEvent(savedMember));
 
             String jwt = jwtService.generateToken(savedMember.getEmail());
             return JwtToken.builder().accessToken(jwt).build();

--- a/src/main/java/grit/stockIt/domain/member/event/MemberRegisteredEvent.java
+++ b/src/main/java/grit/stockIt/domain/member/event/MemberRegisteredEvent.java
@@ -1,0 +1,7 @@
+package grit.stockIt.domain.member.event;
+
+import grit.stockIt.domain.member.entity.Member;
+
+// 회원 가입 완료 이벤트 — 가입 트랜잭션 내부에서 동기 발행된다 (저장된 Member를 그대로 전달, 재조회 금지)
+public record MemberRegisteredEvent(Member member) {
+}

--- a/src/main/java/grit/stockIt/domain/member/service/LocalMemberService.java
+++ b/src/main/java/grit/stockIt/domain/member/service/LocalMemberService.java
@@ -4,8 +4,8 @@ import grit.stockIt.domain.account.service.AccountService;
 import grit.stockIt.domain.member.dto.*;
 import grit.stockIt.domain.member.entity.AuthProvider;
 import grit.stockIt.domain.member.entity.Member;
+import grit.stockIt.domain.member.event.MemberRegisteredEvent;
 import grit.stockIt.domain.member.repository.MemberRepository;
-import grit.stockIt.domain.mission.service.MissionService;
 import grit.stockIt.domain.title.entity.Title;
 import grit.stockIt.domain.title.repository.MemberTitleRepository;
 import grit.stockIt.domain.title.repository.TitleRepository;
@@ -13,6 +13,7 @@ import grit.stockIt.global.jwt.JwtService;
 import grit.stockIt.global.jwt.JwtToken;
 import lombok.RequiredArgsConstructor;
 import java.util.Optional;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,7 +27,7 @@ public class LocalMemberService {
     private final PasswordEncoder passwordEncoder;
     private final JwtService jwtService;
     private final AccountService accountService;
-    private final MissionService missionService; // 미션 보상 지급용
+    private final ApplicationEventPublisher eventPublisher;
     private final TitleRepository titleRepository;
     private final MemberTitleRepository memberTitleRepository;
 
@@ -59,8 +60,8 @@ public class LocalMemberService {
         // 디폴트 계좌 생성 (회원당 1개 보장)
         accountService.createDefaultAccountForMember(savedMember);
 
-        //  미션 시스템 초기화
-        missionService.initializeMissionsForNewMember(savedMember);
+        //  미션 시스템 초기화 (동기 이벤트 — 리스너 예외는 그대로 전파되어 가입 전체 롤백)
+        eventPublisher.publishEvent(new MemberRegisteredEvent(savedMember));
 
         return MemberResponse.from(savedMember);
     }

--- a/src/main/java/grit/stockIt/domain/mission/controller/MissionController.java
+++ b/src/main/java/grit/stockIt/domain/mission/controller/MissionController.java
@@ -4,6 +4,7 @@ import grit.stockIt.domain.mission.dto.*;
 import grit.stockIt.domain.mission.entity.MissionProgress;
 import grit.stockIt.domain.mission.entity.Reward;
 import grit.stockIt.domain.mission.service.MissionService;
+import grit.stockIt.domain.mission.service.MissionQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,6 +25,7 @@ import java.util.stream.Collectors;
 public class MissionController {
 
     private final MissionService missionService;
+    private final MissionQueryService missionQueryService;
     private final MissionScheduler missionScheduler;
 
     /**
@@ -34,7 +36,7 @@ public class MissionController {
     @GetMapping("/dashboard")
     @Operation(summary = "미션 대시보드 요약", description = "메인화면 상단 위젯에 표시할 연속 출석일과 남은 미션 수를 반환합니다.")
     public ResponseEntity<MissionDashboardResponse> getDashboardSummary(@AuthenticationPrincipal UserDetails userDetails) {
-        return ResponseEntity.ok(missionService.getMissionDashboard(userDetails.getUsername()));
+        return ResponseEntity.ok(missionQueryService.getMissionDashboard(userDetails.getUsername()));
     }
 
     /**
@@ -48,7 +50,7 @@ public class MissionController {
             @AuthenticationPrincipal UserDetails userDetails,
             @RequestParam(required = false, defaultValue = "ALL") String track
     ) {
-        return ResponseEntity.ok(missionService.getMissionsByTrack(userDetails.getUsername(), track));
+        return ResponseEntity.ok(missionQueryService.getMissionsByTrack(userDetails.getUsername(), track));
     }
 
     /**
@@ -57,7 +59,7 @@ public class MissionController {
     @GetMapping("/titles")
     @Operation(summary = "보유 칭호 조회", description = "사용자가 획득한 모든 칭호 목록을 반환합니다.")
     public ResponseEntity<List<MemberTitleResponse>> getMyTitles(@AuthenticationPrincipal UserDetails userDetails) {
-        return ResponseEntity.ok(missionService.getMyTitles(userDetails.getUsername()));
+        return ResponseEntity.ok(missionQueryService.getMyTitles(userDetails.getUsername()));
     }
 
     /**
@@ -104,6 +106,6 @@ public class MissionController {
     @GetMapping("/tier")
     @Operation(summary = "티어 및 점수 조회", description = "활동 점수와 실력 점수를 합산한 현재 티어 정보를 반환합니다.")
     public ResponseEntity<UserTierStatusResponse> getMyTierStatus(@AuthenticationPrincipal UserDetails userDetails) {
-        return ResponseEntity.ok(missionService.getTierInfo(userDetails.getUsername()));
+        return ResponseEntity.ok(missionQueryService.getTierInfo(userDetails.getUsername()));
     }
 }

--- a/src/main/java/grit/stockIt/domain/mission/event/RankerAchievedEvent.java
+++ b/src/main/java/grit/stockIt/domain/mission/event/RankerAchievedEvent.java
@@ -1,0 +1,7 @@
+package grit.stockIt.domain.mission.event;
+
+import java.util.List;
+
+// 랭커 달성 이벤트 — 랭킹 갱신 트랜잭션 내부에서 동기 발행된다 (Main 랭킹 Top 10 회원 ID 명단 운반)
+public record RankerAchievedEvent(List<Long> top10MemberIds) {
+}

--- a/src/main/java/grit/stockIt/domain/mission/event/RankerAchievedEvent.java
+++ b/src/main/java/grit/stockIt/domain/mission/event/RankerAchievedEvent.java
@@ -4,4 +4,9 @@ import java.util.List;
 
 // 랭커 달성 이벤트 — 랭킹 갱신 트랜잭션 내부에서 동기 발행된다 (Main 랭킹 Top 10 회원 ID 명단 운반)
 public record RankerAchievedEvent(List<Long> top10MemberIds) {
+
+    public RankerAchievedEvent {
+        // 이벤트는 값이다 — 발행자 리스트 참조를 방어 복사해 완전 불변으로 고정
+        top10MemberIds = List.copyOf(top10MemberIds);
+    }
 }

--- a/src/main/java/grit/stockIt/domain/mission/scheduler/MissionScheduler.java
+++ b/src/main/java/grit/stockIt/domain/mission/scheduler/MissionScheduler.java
@@ -1,6 +1,6 @@
 package grit.stockIt.domain.mission.scheduler;
 
-import grit.stockIt.domain.mission.service.MissionService;
+import grit.stockIt.domain.mission.service.MissionBatchService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class MissionScheduler {
 
-    private final MissionService missionService;
+    private final MissionBatchService missionBatchService;
 
     /**
      * [수정됨] 매일 자정 (00:00)
@@ -24,10 +24,10 @@ public class MissionScheduler {
         try {
             // 1. [순서 중요] 먼저 출석 체크 안 한 사람의 연속 기록을 날려야 함
             // (일일 미션을 리셋해버리면 누가 안 했는지 알 수 없으므로 이게 먼저 와야 함)
-            missionService.checkAndResetAttendanceStreaks();
+            missionBatchService.checkAndResetAttendanceStreaks();
 
             // 2. 그 다음 일일 미션 상태를 0으로 리셋
-            missionService.resetDailyMissions();
+            missionBatchService.resetDailyMissions();
 
             log.info("=== 자정 미션 스케줄러 완료 ===");
         } catch (Exception e) {
@@ -44,7 +44,7 @@ public class MissionScheduler {
     public void dailyHoldingProgressTask() {
         log.info("=== 홀딩 미션 진행도 업데이트 스케줄러 시작 ===");
         try {
-            missionService.processDailyHoldingUpdate();
+            missionBatchService.processDailyHoldingUpdate();
             log.info("=== 홀딩 미션 진행도 업데이트 완료 ===");
         } catch (Exception e) {
             log.error("홀딩 미션 업데이트 중 오류 발생", e);

--- a/src/main/java/grit/stockIt/domain/mission/service/MissionBatchService.java
+++ b/src/main/java/grit/stockIt/domain/mission/service/MissionBatchService.java
@@ -1,0 +1,92 @@
+package grit.stockIt.domain.mission.service;
+
+import grit.stockIt.domain.account.repository.AccountStockRepository;
+import grit.stockIt.domain.member.entity.Member;
+import grit.stockIt.domain.mission.entity.MissionProgress;
+import grit.stockIt.domain.mission.enums.MissionConditionType;
+import grit.stockIt.domain.mission.enums.MissionStatus;
+import grit.stockIt.domain.mission.enums.MissionTrack;
+import grit.stockIt.domain.mission.repository.MissionProgressRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * [B-5 분리] 스케줄러 호출용 배치 서비스 (자정 초기화·홀딩 일수 갱신).
+ * - 진입점: MissionScheduler
+ * - 의존: 리포지토리 + MissionRewardService(단방향, 순환 금지)
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional // 미션 관련 로직은 하나의 트랜잭션으로 관리 (기존 MissionService와 동일 시맨틱스)
+public class MissionBatchService {
+
+    private final MissionProgressRepository missionProgressRepository;
+    private final AccountStockRepository accountStockRepository;
+    private final MissionRewardService missionRewardService;
+
+    /**
+     * [신규] 스케줄러 호출용: 매일 자정에 보유 주식이 있으면 홀딩 일수 +1
+     */
+    public void processDailyHoldingUpdate() {
+        // 1. 'HOLDING_DAYS' 조건이면서 '진행 중'인 미션들만 조회
+        List<MissionProgress> holdingProgressList = missionProgressRepository
+                .findAllByMission_ConditionTypeAndStatus(MissionConditionType.HOLDING_DAYS, MissionStatus.IN_PROGRESS);
+
+        for (MissionProgress progress : holdingProgressList) {
+            Member member = progress.getMember();
+
+            // 2. 회원이 주식을 하나라도 가지고 있는지 확인 (수량 > 0)
+            boolean hasStock = accountStockRepository.existsByAccount_MemberAndQuantityGreaterThan(member, 0);
+
+            if (hasStock) {
+                progress.incrementProgress(1);
+                log.info("홀딩 미션 +1일 증가: MemberId={}, MissionId={}, NewValue={}",
+                        member.getMemberId(), progress.getMission().getId(), progress.getCurrentValue());
+                missionRewardService.checkMissionCompletion(progress);
+            }
+        }
+    }
+
+    /**
+     * [리팩토링] 연속 출석 초기화 로직
+     * - 타입 안전성을 위해 Enum 상수를 직접 인자로 전달합니다.
+     */
+    public void checkAndResetAttendanceStreaks() {
+        log.info("연속 출석 끊김 여부 확인 및 초기화 시작 (Bulk Update)...");
+
+        // 변경된 메서드 시그니처에 맞춰 Enum 값 전달
+        int updatedCount = missionProgressRepository.bulkResetLoginStreakForAbsentees(
+                MissionTrack.ACHIEVEMENT,           // :streakTrack (업적 트랙)
+                MissionConditionType.LOGIN_STREAK,  // :streakCondition (연속 출석 체크용)
+                MissionTrack.DAILY,                 // :dailyTrack (일일 미션 트랙)
+                MissionConditionType.LOGIN_COUNT,   // :dailyCondition (일일 출석 여부 확인용)
+                MissionStatus.COMPLETED             // :completedStatus (완료 상태 기준)
+        );
+
+        log.info("총 {}건의 연속 출석 기록이 일괄 초기화되었습니다.", updatedCount);
+    }
+
+    public void resetDailyMissions() {
+        log.info("일일 미션 전체 초기화 시작...");
+        List<MissionProgress> dailyProgressList = missionProgressRepository.findAllByMission_Track(MissionTrack.DAILY);
+        for (MissionProgress progress : dailyProgressList) {
+            progress.reset();
+        }
+
+        // 2. [신규] Track = ACHIEVEMENT 이지만 'DAILY_TRADE_COUNT' 타입인 미션(카이팅 장인) 초기화
+        // (완료하지 못한 경우에만 리셋해야 함)
+        List<MissionProgress> kitingMissions = missionProgressRepository
+                .findAllByMission_ConditionTypeAndStatus(MissionConditionType.DAILY_TRADE_COUNT, MissionStatus.IN_PROGRESS);
+
+        for (MissionProgress mp : kitingMissions) {
+            // 업적이라 트랙은 ACHIEVEMENT지만 성격은 Daily이므로 매일 리셋
+            mp.setCurrentValue(0);
+        }
+        log.info("일일 미션 총 {}건 초기화 완료.", dailyProgressList.size());
+    }
+}

--- a/src/main/java/grit/stockIt/domain/mission/service/MissionConditionEvaluator.java
+++ b/src/main/java/grit/stockIt/domain/mission/service/MissionConditionEvaluator.java
@@ -1,0 +1,58 @@
+package grit.stockIt.domain.mission.service;
+
+import grit.stockIt.domain.mission.entity.Mission;
+import grit.stockIt.domain.mission.enums.MissionConditionType;
+import grit.stockIt.domain.order.entity.OrderMethod;
+import grit.stockIt.domain.order.event.TradeCompletionEvent;
+import org.springframework.stereotype.Component;
+
+/**
+ * [B-1 추출] 미션 조건 판정 순수 로직.
+ * Spring 컨텍스트 없이 new로 직접 생성하여 단위 테스트할 수 있다.
+ */
+@Component
+public class MissionConditionEvaluator {
+
+    public boolean isMissionConditionMatches(Mission mission, TradeCompletionEvent event) {
+        MissionConditionType type = mission.getConditionType();
+        OrderMethod method = event.getOrderMethod();
+
+        // 매수 전용
+        if (type == MissionConditionType.BUY_COUNT || type == MissionConditionType.BUY_AMOUNT)
+            return method == OrderMethod.BUY;
+
+        // 매도 전용
+        if (type == MissionConditionType.SELL_COUNT || type == MissionConditionType.SELL_AMOUNT ||
+                type == MissionConditionType.PROFIT_RATE || type == MissionConditionType.DAILY_PROFIT_COUNT ||
+                type == MissionConditionType.PROFIT_AMOUNT)
+            return method == OrderMethod.SELL;
+
+        // 공통
+        if (type == MissionConditionType.TRADE_COUNT || type == MissionConditionType.TOTAL_TRADE_AMOUNT ||
+                type == MissionConditionType.DAILY_TRADE_COUNT)
+            return true;
+
+        return false;
+    }
+
+    public boolean isCumulativeType(MissionConditionType type) {
+        return switch (type) {
+            case TRADE_COUNT, BUY_COUNT, SELL_COUNT,
+                 BUY_AMOUNT, SELL_AMOUNT,
+                 TOTAL_TRADE_AMOUNT, DAILY_PROFIT_COUNT, DAILY_TRADE_COUNT,
+
+                 PROFIT_RATE // [추가] 수익률도 이제 차곡차곡 쌓는 '누적형'입니다.
+                    -> true;
+
+            default -> false;
+        };
+    }
+
+    public boolean isThresholdType(MissionConditionType type) {
+        // HOLDING_DAYS는 스케줄러가 처리하므로 제외
+        return switch (type) {
+            case PROFIT_AMOUNT -> true;
+            default -> false;
+        };
+    }
+}

--- a/src/main/java/grit/stockIt/domain/mission/service/MissionEventListener.java
+++ b/src/main/java/grit/stockIt/domain/mission/service/MissionEventListener.java
@@ -15,14 +15,15 @@ import org.springframework.scheduling.annotation.Async;
 public class MissionEventListener {
 
     private final MissionService missionService;
+    private final MissionProgressService missionProgressService;
 
     /**
      * 주식 '체결 완료' 이벤트를 수신합니다.
      */
     @EventListener
     public void handleTradeCompletionEvent(TradeCompletionEvent event) { // 2. [수정] 메서드명과 파라미터 변경
-        // 모든 로직을 MissionService에 위임합니다.
-        missionService.updateMissionProgress(event);
+        // 거래 진행도 로직은 MissionProgressService에 위임합니다.
+        missionProgressService.updateMissionProgress(event);
     }
     /**
      * [신규] 종목 분석 완료 이벤트 수신

--- a/src/main/java/grit/stockIt/domain/mission/service/MissionEventListener.java
+++ b/src/main/java/grit/stockIt/domain/mission/service/MissionEventListener.java
@@ -1,5 +1,6 @@
 package grit.stockIt.domain.mission.service;
 
+import grit.stockIt.domain.member.event.MemberRegisteredEvent;
 import grit.stockIt.domain.mission.event.PortfolioAnalyzedEvent;
 import grit.stockIt.domain.mission.event.StockAnalyzedEvent;
 import grit.stockIt.domain.order.event.TradeCompletionEvent;
@@ -24,6 +25,16 @@ public class MissionEventListener {
     public void handleTradeCompletionEvent(TradeCompletionEvent event) { // 2. [수정] 메서드명과 파라미터 변경
         // 거래 진행도 로직은 MissionProgressService에 위임합니다.
         missionProgressService.updateMissionProgress(event);
+    }
+
+    /**
+     * 회원 가입 완료 이벤트를 수신하여 신규 회원 미션을 초기화합니다.
+     * 동기 리스너 — 가입 트랜잭션에 참여하며, 예외는 발행자(가입 서비스)에게 그대로 전파됩니다.
+     */
+    @EventListener
+    public void handleMemberRegisteredEvent(MemberRegisteredEvent event) {
+        log.info("Event Received: Member Registered for {}", event.member().getEmail());
+        missionService.initializeMissionsForNewMember(event.member());
     }
     /**
      * [신규] 종목 분석 완료 이벤트 수신

--- a/src/main/java/grit/stockIt/domain/mission/service/MissionEventListener.java
+++ b/src/main/java/grit/stockIt/domain/mission/service/MissionEventListener.java
@@ -34,7 +34,7 @@ public class MissionEventListener {
      */
     @EventListener
     public void handleMemberRegisteredEvent(MemberRegisteredEvent event) {
-        log.info("Event Received: Member Registered for {}", event.member().getEmail());
+        log.info("Event Received: Member Registered for memberId={}", event.member().getMemberId());
         missionService.initializeMissionsForNewMember(event.member());
     }
 

--- a/src/main/java/grit/stockIt/domain/mission/service/MissionEventListener.java
+++ b/src/main/java/grit/stockIt/domain/mission/service/MissionEventListener.java
@@ -2,6 +2,7 @@ package grit.stockIt.domain.mission.service;
 
 import grit.stockIt.domain.member.event.MemberRegisteredEvent;
 import grit.stockIt.domain.mission.event.PortfolioAnalyzedEvent;
+import grit.stockIt.domain.mission.event.RankerAchievedEvent;
 import grit.stockIt.domain.mission.event.StockAnalyzedEvent;
 import grit.stockIt.domain.order.event.TradeCompletionEvent;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +36,16 @@ public class MissionEventListener {
     public void handleMemberRegisteredEvent(MemberRegisteredEvent event) {
         log.info("Event Received: Member Registered for {}", event.member().getEmail());
         missionService.initializeMissionsForNewMember(event.member());
+    }
+
+    /**
+     * 랭커 달성 이벤트를 수신하여 Top 10 명단의 랭커 미션 진행/완료를 처리합니다.
+     * 동기 리스너 — 예외는 발행자(RankingService)에게 그대로 전파되어 기존 catch에 흡수됩니다.
+     */
+    @EventListener
+    public void handleRankerAchievedEvent(RankerAchievedEvent event) {
+        log.info("Event Received: Ranker Achieved for {} members", event.top10MemberIds().size());
+        missionProgressService.processRankerAchievement(event.top10MemberIds());
     }
     /**
      * [신규] 종목 분석 완료 이벤트 수신

--- a/src/main/java/grit/stockIt/domain/mission/service/MissionProgressCalculator.java
+++ b/src/main/java/grit/stockIt/domain/mission/service/MissionProgressCalculator.java
@@ -1,0 +1,114 @@
+package grit.stockIt.domain.mission.service;
+
+import grit.stockIt.domain.mission.enums.MissionConditionType;
+import grit.stockIt.domain.order.entity.OrderMethod;
+import grit.stockIt.domain.order.event.TradeCompletionEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+
+/**
+ * [B-1 추출] 미션 진행도/점수 계산 순수 로직.
+ * Spring 컨텍스트 없이 new로 직접 생성하여 단위 테스트할 수 있다.
+ */
+@Slf4j
+@Component
+public class MissionProgressCalculator {
+
+    public int calculateIncreaseValue(MissionConditionType type, TradeCompletionEvent event) {
+        return switch (type) {
+            case TRADE_COUNT, BUY_COUNT, SELL_COUNT, DAILY_TRADE_COUNT -> 1;
+
+            case BUY_AMOUNT, SELL_AMOUNT, TOTAL_TRADE_AMOUNT ->
+                    event.getFilledAmount().intValue();
+
+            case DAILY_PROFIT_COUNT -> {
+                // 매도(SELL)이면서, 체결가가 평단가보다 크면 익절 (1회 증가)
+                boolean isSell = event.getOrderMethod() == OrderMethod.SELL;
+                boolean isProfit = event.getFilledPrice().compareTo(event.getBuyAveragePrice()) > 0;
+                yield (isSell && isProfit) ? 1 : 0;
+            }
+
+            // [신규 이동] 수익률 누적 계산
+            case PROFIT_RATE -> {
+                if (event.getOrderMethod() != OrderMethod.SELL) yield 0;
+
+                BigDecimal sellPrice = event.getFilledPrice();
+                BigDecimal avgBuyPrice = event.getBuyAveragePrice();
+
+                if (avgBuyPrice == null || avgBuyPrice.compareTo(BigDecimal.ZERO) == 0) {
+                    yield 0;
+                }
+
+                // 수익률 공식: ((매도가 - 평단가) / 평단가) * 100
+                BigDecimal profitRate = sellPrice.subtract(avgBuyPrice)
+                        .divide(avgBuyPrice, 4, java.math.RoundingMode.HALF_UP)
+                        .multiply(BigDecimal.valueOf(100));
+
+                // 예: 5.5% 수익 -> 6점 증가 (반올림)
+                // 예: -10% 손실 -> -10점 (진행도 깎임) -> 원치 않으시면 Math.max(0, ...) 처리 필요
+                yield profitRate.setScale(0, java.math.RoundingMode.HALF_UP).intValue();
+            }
+
+            default -> 0;
+        };
+    }
+
+    // [수정] 값 계산 시 반올림 적용 (선택 사항이나 권장)
+    public int calculateThresholdValue(MissionConditionType type, TradeCompletionEvent event) {
+        // 매도가 아니면 수익률/수익금 계산 불가
+        if (event.getOrderMethod() != OrderMethod.SELL) return 0;
+
+        // 1. 수익률 (PROFIT_RATE) 계산
+        if (type == MissionConditionType.PROFIT_RATE) {
+            // [수정] event.getProfitRate()를 신뢰하지 않고 직접 계산 로직을 우선 사용
+
+            BigDecimal sellPrice = event.getFilledPrice();     // 매도 체결가
+            BigDecimal avgBuyPrice = event.getBuyAveragePrice(); // 평단가
+
+            // 평단가가 0이거나 없으면 계산 불가 (0 리턴)
+            if (avgBuyPrice == null || avgBuyPrice.compareTo(BigDecimal.ZERO) == 0) {
+                log.warn("수익률 계산 실패: 평단가가 0입니다. StockCode={}", event.getStockCode());
+                return 0;
+            }
+
+            // 공식: ((매도가 - 평단가) / 평단가) * 100
+            // 예: 매도가 10500, 평단가 10000 -> (500 / 10000) * 100 = 5%
+            BigDecimal profitRate = sellPrice.subtract(avgBuyPrice)
+                    .divide(avgBuyPrice, 4, java.math.RoundingMode.HALF_UP) // 소수점 4자리까지 확보 (0.0500)
+                    .multiply(BigDecimal.valueOf(100)); // 백분율 변환 (5.00)
+
+            // 로그로 계산 과정 출력 (디버깅용)
+            log.info("수익률 계산: ({} - {}) / {} * 100 = {}%",
+                    sellPrice, avgBuyPrice, avgBuyPrice, profitRate);
+
+            // 소수점 반올림하여 정수로 반환 (예: 4.9% -> 5%, 4.4% -> 4%)
+            return profitRate.setScale(0, java.math.RoundingMode.HALF_UP).intValue();
+        }
+
+        // 2. 수익금 (PROFIT_AMOUNT) 계산
+        if (type == MissionConditionType.PROFIT_AMOUNT) {
+            // 수익금은 직접 계산: (판 금액 - (평단가 * 수량))
+            BigDecimal totalSellAmount = event.getFilledAmount();
+            BigDecimal totalBuyCost = event.getBuyAveragePrice()
+                    .multiply(BigDecimal.valueOf(event.getFilledQuantity()));
+
+            BigDecimal profitAmount = totalSellAmount.subtract(totalBuyCost);
+
+            return profitAmount.intValue();
+        }
+
+        return 0;
+    }
+
+    /**
+     * [신규] 수익금을 점수로 환산하는 헬퍼 메서드
+     * - 공식: Score = sqrt(max(0, TotalProfit))
+     * - 수익금이 마이너스(손실 중)라면 0점으로 처리
+     */
+    public int calculateScoreFromProfit(int totalProfit) {
+        if (totalProfit <= 0) return 0;
+        return (int) Math.sqrt(totalProfit / 10.0);
+    }
+}

--- a/src/main/java/grit/stockIt/domain/mission/service/MissionProgressService.java
+++ b/src/main/java/grit/stockIt/domain/mission/service/MissionProgressService.java
@@ -1,0 +1,282 @@
+package grit.stockIt.domain.mission.service;
+
+import grit.stockIt.domain.account.entity.Account;
+import grit.stockIt.domain.account.repository.AccountRepository;
+import grit.stockIt.domain.member.entity.Member;
+import grit.stockIt.domain.member.repository.MemberRepository;
+import grit.stockIt.domain.mission.entity.Mission;
+import grit.stockIt.domain.mission.entity.MissionProgress;
+import grit.stockIt.domain.mission.enums.MissionConditionType;
+import grit.stockIt.domain.mission.enums.MissionStatus;
+import grit.stockIt.domain.mission.enums.MissionTrack;
+import grit.stockIt.domain.mission.repository.MissionProgressRepository;
+import grit.stockIt.domain.mission.repository.MissionRepository;
+import grit.stockIt.domain.order.entity.OrderMethod;
+import grit.stockIt.domain.order.event.TradeCompletionEvent;
+import grit.stockIt.domain.stock.entity.Stock;
+import grit.stockIt.domain.stock.repository.StockRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * [B-4 분리] 거래 이벤트 기반 미션 진행도 갱신 서비스.
+ * - 진입점: updateMissionProgress(TradeCompletionEvent), processRankerAchievement(랭킹 스케줄러 호출)
+ * - 의존: 리포지토리 + B-1 순수 클래스 + MissionRewardService(단방향, 순환 금지)
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional // 미션 관련 로직은 하나의 트랜잭션으로 관리 (기존 MissionService와 동일 시맨틱스)
+public class MissionProgressService {
+
+    private final MemberRepository memberRepository;
+    private final MissionRepository missionRepository;
+    private final MissionProgressRepository missionProgressRepository;
+    private final AccountRepository accountRepository;
+    private final StockRepository stockRepository;
+    private final MissionConditionEvaluator missionConditionEvaluator;
+    private final MissionProgressCalculator missionProgressCalculator;
+    private final MissionRewardService missionRewardService;
+
+    private static final long JUNK_STOCK_MARKET_CAP_THRESHOLD = 100000000000L;
+
+    /**
+     * [1] (이벤트 수신) 거래 이벤트 발생 시 미션 진행도 업데이트
+     * - 일반 미션 갱신 로직
+     * - 매도(SELL) 발생 시 '홀딩' 미션 초기화 로직 포함
+     */
+    public void updateMissionProgress(TradeCompletionEvent event) {
+        log.info("수신된 거래 이벤트: MemberId={}, Method={}, Qty={}",
+                event.getMemberId(), event.getOrderMethod(), event.getFilledQuantity());
+
+        // 🛑 [신규 추가] 기본 계좌 검증 로직
+        // 1. 이벤트에 계좌 ID가 없거나, 기본 계좌가 아니면 미션 집계에서 제외
+        if (event.getAccountId() != null) {
+            boolean isDefaultAccount = accountRepository.findById(event.getAccountId())
+                    .map(Account::getIsDefault)
+                    .orElse(false); // 계좌가 없으면 false 취급
+
+            if (!isDefaultAccount) {
+                log.info("보조 계좌 거래 감지: 미션 및 랭킹 집계에서 제외합니다. (AccountId={})", event.getAccountId());
+                return; // 여기서 메서드 종료!
+            }
+        } else {
+            // (선택 사항) AccountId가 null인 옛날 코드 호환성을 위해 경고만 찍고 진행할지, 막을지 결정
+            // 여기서는 안전하게 로그 찍고 진행 (혹은 return으로 막으셔도 됨)
+            log.warn("거래 이벤트에 AccountId가 없습니다. 기본 계좌 여부를 확인할 수 없습니다.");
+        }
+
+        Member member = memberRepository.findById(event.getMemberId())
+                .orElseThrow(() -> new EntityNotFoundException("회원을 찾을 수 없습니다."));
+
+        // 1. 회원의 '진행 중'인 미션 목록 조회
+        List<MissionProgress> progressList = missionProgressRepository
+                .findByMemberAndStatusWithMission(member, MissionStatus.IN_PROGRESS);
+
+        // 2. 진행 중인 미션 순회
+        for (MissionProgress progress : progressList) {
+            Mission mission = progress.getMission();
+            MissionConditionType type = mission.getConditionType();
+
+            // 🚨 [핵심 로직] 매도(SELL) 발생 시 -> '홀딩' 미션은 무조건 0으로 초기화 (존버 실패)
+            if (event.getOrderMethod() == OrderMethod.SELL && type == MissionConditionType.HOLDING_DAYS) {
+                if (progress.getCurrentValue() > 0) {
+                    log.info("매도 발생으로 홀딩 미션 리셋! MissionId={}, 기존값={}",
+                            mission.getId(), progress.getCurrentValue());
+                    progress.setCurrentValue(0); // 0일차로 초기화
+                }
+                continue; // 초기화했으니 다른 검사는 건너뜀
+            }
+
+            // 3. 그 외 조건 매칭 여부 확인 및 업데이트
+            if (missionConditionEvaluator.isMissionConditionMatches(mission, event)) {
+                updateProgressValue(progress, mission, event);
+            }
+        }
+        // 2. [신규] 특수 업적 미션 체크 (달콤한 첫입, 강형욱)
+        checkSpecialAchievement(member, event);
+
+        // [추가] 매도(SELL) 발생 시 실력 점수 반영
+        if (event.getOrderMethod() == OrderMethod.SELL) {
+            updateSkillScore(event);
+        }
+    }
+
+    /**
+     * [수정] 실력 점수 로직 -> "누적 수익금 업데이트"로 변경
+     * - 매도 시 발생한 수익금(손실금)을 있는 그대로 더함
+     * - 점수 변환(제곱근)은 조회 시점에 수행
+     */
+    private void updateSkillScore(TradeCompletionEvent event) {
+        Member member = memberRepository.findById(event.getMemberId()).orElseThrow();
+
+        // 1. 이번 거래의 수익금 계산
+        BigDecimal sellAmount = event.getFilledAmount();
+        BigDecimal buyCost = event.getBuyAveragePrice().multiply(BigDecimal.valueOf(event.getFilledQuantity()));
+        BigDecimal profit = sellAmount.subtract(buyCost);
+
+        int profitInt = profit.intValue(); // 억 단위 이상이 아니라면 int로 충분
+        if (profitInt == 0) return;
+
+        // 2. 트래커(ID 999)에 수익금 누적
+        missionProgressRepository.findByMemberAndMissionTypeWithMission(member, MissionTrack.ACHIEVEMENT, MissionConditionType.SKILL_SCORE)
+                .ifPresent(tracker -> {
+                    int currentTotalProfit = tracker.getCurrentValue();
+                    int newTotalProfit = currentTotalProfit + profitInt;
+
+                    // 순수 수익금 저장 (마이너스 수익이면 전체 수익금이 깎임)
+                    tracker.setCurrentValue(newTotalProfit);
+
+                    log.info("누적 수익금 갱신: Member={}, 이번수익={}원, 총누적={}원",
+                            member.getName(), profitInt, newTotalProfit);
+
+                    // Legend 달성 체크 (현재 총 수익금 기반으로 점수 환산하여 체크)
+                    missionRewardService.checkLegendTier(member, getActivityScore(member) + missionProgressCalculator.calculateScoreFromProfit(newTotalProfit));
+                });
+    }
+
+    /**
+     * [Helper] 현재 활동 점수(Activity Score) 조회
+     * - 트래커 미션(998번)의 현재 값을 가져옴
+     * - 없으면 0점 반환
+     */
+    private int getActivityScore(Member member) {
+        return missionProgressRepository.findByMemberAndMissionTypeWithMission(
+                        member,
+                        MissionTrack.ACHIEVEMENT,
+                        MissionConditionType.ACTIVITY_SCORE
+                )
+                .map(MissionProgress::getCurrentValue)
+                .orElse(0);
+    }
+
+    /**
+     * [신규] 특수 조건 업적 처리
+     * - 달콤한 첫입 (FIRST_PROFIT)
+     * - 강형욱 (JUNK_STOCK_JACKPOT)
+     */
+    private void checkSpecialAchievement(Member member, TradeCompletionEvent event) {
+        // 매도가 아니거나 수익이 없으면 패스
+        if (event.getOrderMethod() != OrderMethod.SELL) return;
+
+        // 수익 여부 판단 (매도가 > 평단가)
+        boolean isProfit = event.getFilledPrice().compareTo(event.getBuyAveragePrice()) > 0;
+        if (!isProfit) return;
+
+        // A. 달콤한 첫입 (첫 수익 실현)
+        handleOneTimeAchievement(member, MissionConditionType.FIRST_PROFIT, 1);
+
+        // B. 강형욱 (잡주로 100% 이상 수익)
+        // 종목 정보 조회
+        Stock stock = stockRepository.findById(event.getStockCode()).orElse(null);
+
+/*        // 시가총액 1,000억 미만이고, 수익률이 100% 이상인 경우
+        if (stock != null && stock.getMarketCap() < JUNK_STOCK_MARKET_CAP_THRESHOLD) {
+            // 수익률 계산: (매도가 - 평단가) / 평단가
+            BigDecimal profitRate = event.getFilledPrice().subtract(event.getBuyAveragePrice())
+                    .divide(event.getBuyAveragePrice(), 2, java.math.RoundingMode.HALF_UP);
+
+            // 1.0 이상 (100%)
+            if (profitRate.compareTo(BigDecimal.ONE) >= 0) {
+                log.info("잡주 대박 터짐! Member={}, Stock={}, Rate={}", member.getName(), stock.getName(), profitRate);
+                handleOneTimeAchievement(member, MissionConditionType.JUNK_STOCK_JACKPOT, 1);
+            }
+        }*/
+    }
+
+    /**
+     * 1회성 업적 달성 처리 헬퍼 (이미 완료되었으면 무시)
+     */
+    private void handleOneTimeAchievement(Member member, MissionConditionType type, int value) {
+        missionProgressRepository.findByMemberAndMissionTypeWithMission(member, MissionTrack.ACHIEVEMENT, type)
+                .ifPresent(progress -> {
+                    if (!progress.isCompleted()) {
+                        progress.setCurrentValue(value);
+                        missionRewardService.checkMissionCompletion(progress);
+                    }
+                });
+    }
+
+    // [수정] 진행도 업데이트 로직 개선
+    private void updateProgressValue(MissionProgress progress, Mission mission, TradeCompletionEvent event) {
+        MissionConditionType type = mission.getConditionType();
+        int goal = mission.getGoalValue();
+
+        // A. 누적형 (카운트 증가) - 기존과 동일
+        if (missionConditionEvaluator.isCumulativeType(type)) {
+            int valueToIncrease = missionProgressCalculator.calculateIncreaseValue(type, event);
+            if (valueToIncrease > 0) {
+                progress.incrementProgress(valueToIncrease);
+                log.info("미션(누적) 갱신: MissionId={}, Added={}, Current={}",
+                        mission.getId(), valueToIncrease, progress.getCurrentValue());
+                missionRewardService.checkMissionCompletion(progress);
+            }
+        }
+        // B. 달성형 (임계값 돌파 / 최고 기록 갱신) - [수정됨]
+        else if (missionConditionEvaluator.isThresholdType(type)) {
+            int eventValue = missionProgressCalculator.calculateThresholdValue(type, event);
+
+            // 현재 기록보다 더 높은 기록이 나오면 갱신 (Best Record)
+            if (eventValue > progress.getCurrentValue()) {
+                // 목표치보다 크면 목표치로 고정 (100% 달성 표시를 위해)
+                int newValue = Math.min(eventValue, goal);
+                progress.setCurrentValue(newValue);
+
+                log.info("미션(달성형) 기록 갱신: MissionId={}, NewBest={}, Goal={}",
+                        mission.getId(), newValue, goal);
+
+                // 목표 달성 여부 체크
+                if (eventValue >= goal) {
+                    missionRewardService.checkMissionCompletion(progress);
+                }
+            }
+        }
+    }
+
+    /**
+     * [신규] 랭킹 Top 10 달성 처리 (스케줄러 호출용)
+     * - RankingService에서 1분마다 Top 10 유저 ID 리스트를 넘겨줌
+     */
+    public void processRankerAchievement(List<Long> topRankerIds) {
+        if (topRankerIds.isEmpty()) return;
+
+        // 1. 'RANKING_TOP_10' 조건의 업적 미션 조회 (미션 ID: 909 '랭커')
+        Mission rankerMission = missionRepository.findAllByTrackAndConditionType(MissionTrack.ACHIEVEMENT, MissionConditionType.RANKING_TOP_10)
+                .stream().findFirst()
+                .orElse(null);
+
+        if (rankerMission == null) return;
+
+        // 2. Top 10 유저들을 순회하며 미션 달성 처리
+        for (Long memberId : topRankerIds) {
+            Member member = memberRepository.findById(memberId).orElse(null);
+            if (member == null) continue;
+
+            // 3. 미션 진행도 조회 또는 생성
+            MissionProgress progress = missionProgressRepository
+                    .findByMemberAndMission(member, rankerMission)
+                    .orElseGet(() -> {
+                        MissionProgress newProgress = MissionProgress.builder()
+                                .member(member)
+                                .mission(rankerMission)
+                                .status(MissionStatus.IN_PROGRESS)
+                                .build();
+                        member.addMissionProgress(newProgress);
+                        return newProgress;
+                    });
+
+            // 4. 이미 완료한 사람은 패스 (칭호 중복 지급 방지)
+            if (!progress.isCompleted()) {
+                log.info("랭커 등극! 칭호 지급: MemberId={}", memberId);
+                progress.setCurrentValue(10); // 목표치(10) 달성 처리
+                missionRewardService.checkMissionCompletion(progress); // 보상(칭호) 지급 및 완료 처리
+            }
+        }
+    }
+}

--- a/src/main/java/grit/stockIt/domain/mission/service/MissionQueryService.java
+++ b/src/main/java/grit/stockIt/domain/mission/service/MissionQueryService.java
@@ -1,0 +1,235 @@
+package grit.stockIt.domain.mission.service;
+
+import grit.stockIt.domain.member.entity.Member;
+import grit.stockIt.domain.member.repository.MemberRepository;
+import grit.stockIt.domain.mission.dto.MemberTitleResponse;
+import grit.stockIt.domain.mission.dto.MissionDashboardResponse;
+import grit.stockIt.domain.mission.dto.MissionListResponse;
+import grit.stockIt.domain.mission.dto.UserTierStatusResponse;
+import grit.stockIt.domain.mission.entity.MissionProgress;
+import grit.stockIt.domain.mission.enums.MissionConditionType;
+import grit.stockIt.domain.mission.enums.MissionTrack;
+import grit.stockIt.domain.mission.repository.MissionProgressRepository;
+import grit.stockIt.domain.title.repository.MemberTitleRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * [B-2 분리] 미션 조회 전용 서비스 (읽기 전용 트랜잭션).
+ * MissionController GET 4개와 RankingService.getTierForMember가 진입점이다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MissionQueryService {
+
+    private final MemberRepository memberRepository;
+    private final MissionProgressRepository missionProgressRepository;
+    private final MemberTitleRepository memberTitleRepository;
+    private final MissionProgressCalculator missionProgressCalculator;
+
+    // 대시보드용 요약 정보 조회
+    public MissionDashboardResponse getMissionDashboard(String email) {
+        Member member = getMemberByEmail(email);
+
+        // 1. 연속 출석 일수 (업적 중 LOGIN_STREAK 타입의 현재 진행도 조회)
+// 7일, 15일, 30일 업적 미션들과 충돌하지 않음
+        int streak = missionProgressRepository
+                .findTopByMemberAndConditionOrderByGoalDesc(member, MissionTrack.ACHIEVEMENT, MissionConditionType.LOGIN_STREAK)
+                .map(MissionProgress::getCurrentValue)
+                .orElse(0); // 트래커 미션이 아직 생성 안 됐으면 0일
+
+        // 2. 남은 일일 미션 개수 (DAILY 트랙 중, 완료되지 않은 것의 개수)
+        List<MissionProgress> dailyMissions = missionProgressRepository.findAllByMemberAndMission_Track(member, MissionTrack.DAILY);
+        int remaining = (int) dailyMissions.stream()
+                .filter(mp -> !mp.isCompleted())
+                .count();
+
+        return MissionDashboardResponse.builder()
+                .consecutiveAttendanceDays(streak)
+                .remainingDailyMissions(remaining)
+                .build();
+    }
+
+    // 트랙별 미션 리스트 조회 (Enum 변환을 통한 안정성 확보)
+    public List<MissionListResponse> getMissionsByTrack(String email, String trackName) {
+        Member member = getMemberByEmail(email);
+        List<MissionProgress> allProgress = missionProgressRepository.findByMemberWithMissionAndReward(member);
+
+        // 1. "ALL"인 경우 전체 반환 (대소문자 무시: all, ALL 등)
+        if (trackName == null || "ALL".equalsIgnoreCase(trackName)) {
+            return allProgress.stream()
+                    .map(MissionListResponse::new)
+                    .collect(Collectors.toList());
+        }
+
+        // 2. 특정 트랙 필터링 (Enum 변환 시도)
+        try {
+            // 입력값을 대문자로 변환하여 Enum 매핑 (daily -> DAILY)
+            MissionTrack filterTrack = MissionTrack.valueOf(trackName.toUpperCase());
+
+            return allProgress.stream()
+                    .filter(mp -> mp.getMission().getTrack() == filterTrack) // Enum 타입 비교 (==)
+                    .map(MissionListResponse::new)
+                    .collect(Collectors.toList());
+
+        } catch (IllegalArgumentException e) {
+            // 정의되지 않은 트랙 이름이 들어온 경우 (예: "ABCD")
+            log.warn("유효하지 않은 미션 트랙 요청: email={}, track={}", email, trackName);
+            return List.of(); // 빈 리스트 반환하여 에러 방지
+        }
+    }
+
+    // 보유 칭호 목록 조회
+    public List<MemberTitleResponse> getMyTitles(String email) {
+        Member member = getMemberByEmail(email);
+        return memberTitleRepository.findAllByMember(member).stream()
+                .map(MemberTitleResponse::new)
+                .collect(Collectors.toList());
+    }
+
+    public UserTierStatusResponse getTierInfo(String email) {
+        Member member = getMemberByEmail(email);
+
+        // 1. 활동 점수
+        int activityScore = missionProgressRepository.findByMemberAndMissionTypeWithMission(member, MissionTrack.ACHIEVEMENT, MissionConditionType.ACTIVITY_SCORE)
+                .map(MissionProgress::getCurrentValue).orElse(0);
+
+        // 2. 실력 점수
+        int totalProfit = missionProgressRepository.findByMemberAndMissionTypeWithMission(member, MissionTrack.ACHIEVEMENT, MissionConditionType.SKILL_SCORE)
+                .map(MissionProgress::getCurrentValue).orElse(0);
+
+        int skillScore = missionProgressCalculator.calculateScoreFromProfit(totalProfit);
+        int totalScore = activityScore + skillScore;
+
+        // 3. 티어 계산
+        String currentTier;
+        String nextTier;
+        int nextTierScore;        // 다음 티어 승급 점수 (목표)
+        int currentTierStartScore; // [신규] 현재 티어 시작 점수 (진행도 계산용)
+
+        if (totalScore < 800) {
+            currentTier = "BRONZE 1";
+            nextTier = "BRONZE 2";
+            currentTierStartScore = 0;   // 0 ~ 799
+            nextTierScore = 800;
+        } else if (totalScore < 1000) {
+            currentTier = "BRONZE 2";
+            nextTier = "BRONZE 3";
+            currentTierStartScore = 800; // 800 ~ 999
+            nextTierScore = 1000;
+        } else if (totalScore < 1200) {
+            currentTier = "BRONZE 3";
+            nextTier = "SILVER 1";
+            currentTierStartScore = 1000; // 1000 ~ 1199
+            nextTierScore = 1200;
+        } else if (totalScore < 1400) {
+            currentTier = "SILVER 1";
+            nextTier = "SILVER 2";
+            currentTierStartScore = 1200; // 1200 ~ 1399 (신규 유저 시작 구간)
+            nextTierScore = 1400;
+        } else if (totalScore < 1600) {
+            currentTier = "SILVER 2";
+            nextTier = "SILVER 3";
+            currentTierStartScore = 1400;
+            nextTierScore = 1600;
+        } else if (totalScore < 1800) {
+            currentTier = "SILVER 3";
+            nextTier = "GOLD 1";
+            currentTierStartScore = 1600;
+            nextTierScore = 1800;
+        } else if (totalScore < 2000) {
+            currentTier = "GOLD 1";
+            nextTier = "GOLD 2";
+            currentTierStartScore = 1800;
+            nextTierScore = 2000;
+        } else if (totalScore < 2200) {
+            currentTier = "GOLD 2";
+            nextTier = "GOLD 3";
+            currentTierStartScore = 2000;
+            nextTierScore = 2200;
+        } else if (totalScore < 2400) {
+            currentTier = "GOLD 3";
+            nextTier = "MASTER 1";
+            currentTierStartScore = 2200;
+            nextTierScore = 2400;
+        } else if (totalScore < 2600) {
+            currentTier = "MASTER 1";
+            nextTier = "MASTER 2";
+            currentTierStartScore = 2400;
+            nextTierScore = 2600;
+        } else if (totalScore < 2800) {
+            currentTier = "MASTER 2";
+            nextTier = "MASTER 3";
+            currentTierStartScore = 2600;
+            nextTierScore = 2800;
+        } else if (totalScore < 3000) {
+            currentTier = "MASTER 3";
+            nextTier = "GRANDMASTER 1";
+            currentTierStartScore = 2800;
+            nextTierScore = 3000;
+        } else if (totalScore < 3200) {
+            currentTier = "GRANDMASTER 1";
+            nextTier = "GRANDMASTER 2";
+            currentTierStartScore = 3000;
+            nextTierScore = 3200;
+        } else if (totalScore < 3400) {
+            currentTier = "GRANDMASTER 2";
+            nextTier = "GRANDMASTER 3";
+            currentTierStartScore = 3200;
+            nextTierScore = 3400;
+        } else if (totalScore < 3600) {
+            currentTier = "GRANDMASTER 3";
+            nextTier = "LEGEND";
+            currentTierStartScore = 3400;
+            nextTierScore = 3600;
+        } else {
+            currentTier = "LEGEND";
+            nextTier = "MAX";
+            currentTierStartScore = 3600;
+            nextTierScore = totalScore; // Legend는 목표치가 없으므로 현재 점수와 동일시
+        }
+
+        // 4. 진행도 계산 (현재 구간 내에서의 %)
+        double progress = 0.0;
+        if (!"MAX".equals(nextTier)) {
+            // 공식: (현재점수 - 시작점수) / (목표점수 - 시작점수) * 100
+            double gainedInCurrentTier = (double) (totalScore - currentTierStartScore);
+            double rangeOfCurrentTier = (double) (nextTierScore - currentTierStartScore);
+
+            if (rangeOfCurrentTier > 0) {
+                progress = (gainedInCurrentTier / rangeOfCurrentTier) * 100.0;
+            }
+        } else {
+            progress = 100.0;
+        }
+
+        return UserTierStatusResponse.builder()
+                .currentTier(currentTier)
+                .nextTier(nextTier)
+                .totalScore(totalScore)
+                .activityScore(activityScore)
+                .skillScore(skillScore)
+                .scoreToNextTier(nextTierScore - totalScore)
+                .progressPercentage(progress)
+                .build();
+    }
+
+    public List<MissionProgress> getMissionProgressList(String email) {
+        Member member = getMemberByEmail(email);
+        return missionProgressRepository.findByMemberWithMissionAndReward(member);
+    }
+
+    // getMemberByEmail은 B-6 방침과 동일하게 private 복제 (과추상화 금지)
+    private Member getMemberByEmail(String email) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> new EntityNotFoundException("회원을 찾을 수 없습니다. Email: " + email));
+    }
+}

--- a/src/main/java/grit/stockIt/domain/mission/service/MissionQueryService.java
+++ b/src/main/java/grit/stockIt/domain/mission/service/MissionQueryService.java
@@ -185,15 +185,15 @@ public class MissionQueryService {
             nextTier = "GRANDMASTER 3";
             currentTierStartScore = 3200;
             nextTierScore = 3400;
-        } else if (totalScore < 3600) {
+        } else if (totalScore < MissionTierPolicy.LEGEND_THRESHOLD_SCORE) {
             currentTier = "GRANDMASTER 3";
             nextTier = "LEGEND";
             currentTierStartScore = 3400;
-            nextTierScore = 3600;
+            nextTierScore = MissionTierPolicy.LEGEND_THRESHOLD_SCORE;
         } else {
             currentTier = "LEGEND";
             nextTier = "MAX";
-            currentTierStartScore = 3600;
+            currentTierStartScore = MissionTierPolicy.LEGEND_THRESHOLD_SCORE;
             nextTierScore = totalScore; // Legend는 목표치가 없으므로 현재 점수와 동일시
         }
 

--- a/src/main/java/grit/stockIt/domain/mission/service/MissionRewardService.java
+++ b/src/main/java/grit/stockIt/domain/mission/service/MissionRewardService.java
@@ -74,7 +74,7 @@ public class MissionRewardService {
 
     // 레전드 미션(903) 달성 체크
     public void checkLegendTier(Member member, int totalScore) {
-        if (totalScore >= 3600) { // Legend 기준 점수
+        if (totalScore >= MissionTierPolicy.LEGEND_THRESHOLD_SCORE) { // Legend 기준 점수
             missionRepository.findAllByTrackAndConditionType(MissionTrack.ACHIEVEMENT, MissionConditionType.REACH_LEGEND)
                     .stream().findFirst().ifPresent(legendMission -> {
                         missionProgressRepository.findByMemberAndMission(member, legendMission)

--- a/src/main/java/grit/stockIt/domain/mission/service/MissionRewardService.java
+++ b/src/main/java/grit/stockIt/domain/mission/service/MissionRewardService.java
@@ -1,0 +1,274 @@
+package grit.stockIt.domain.mission.service;
+
+import grit.stockIt.domain.account.repository.AccountRepository;
+import grit.stockIt.domain.member.entity.Member;
+import grit.stockIt.domain.mission.entity.Mission;
+import grit.stockIt.domain.mission.entity.MissionProgress;
+import grit.stockIt.domain.mission.entity.Reward;
+import grit.stockIt.domain.mission.enums.MissionConditionType;
+import grit.stockIt.domain.mission.enums.MissionStatus;
+import grit.stockIt.domain.mission.enums.MissionTrack;
+import grit.stockIt.domain.mission.enums.MissionType;
+import grit.stockIt.domain.mission.repository.MissionProgressRepository;
+import grit.stockIt.domain.mission.repository.MissionRepository;
+import grit.stockIt.domain.notification.event.MissionCompletedEvent;
+import grit.stockIt.domain.title.entity.MemberTitle;
+import grit.stockIt.domain.title.repository.MemberTitleRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * [B-3 분리] 미션 완료 판정·보상 지급·체인 처리 서비스.
+ * 의존은 리포지토리 + B-1 순수 클래스 + 자기 자신뿐인 sink — 다른 미션 서비스를 주입하지 않는다(순환 금지).
+ * 완료 체인의 재진입(checkMissionCompletion -> handleMissionChain -> updateSpecificAchievement ->
+ * checkMissionCompletion)은 전부 이 클래스 내부 자기호출로 닫힌다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional // 미션 관련 로직은 하나의 트랜잭션으로 관리 (기존 MissionService와 동일 시맨틱스)
+public class MissionRewardService {
+
+    private final MissionRepository missionRepository;
+    private final MissionProgressRepository missionProgressRepository;
+    private final MemberTitleRepository memberTitleRepository;
+    private final AccountRepository accountRepository;
+    private final ApplicationEventPublisher eventPublisher;
+    private final MissionTrackPolicy missionTrackPolicy;
+
+    private static final int MISSION_COMPLETION_ACTIVITY_POINTS = 10;
+
+    public void checkMissionCompletion(MissionProgress progress) {
+        if (progress.getStatus() == MissionStatus.COMPLETED || !progress.isCompleted()) {
+            return;
+        }
+
+        progress.complete();
+        log.info("미션 완료: MemberId={}, MissionId={}", progress.getMember().getMemberId(), progress.getMission().getId());
+
+        Mission mission = progress.getMission();
+        Reward reward = mission.getReward();
+
+        // 보상 지급
+        distributeReward(progress.getMember(), reward);
+
+        // 출석 미션은 알림 발송 제외
+        if (mission.getConditionType() != MissionConditionType.LOGIN_COUNT) {
+            // 미션 완료 알림 이벤트 발행
+            publishMissionCompletedEvent(progress.getMember(), mission, reward);
+        }
+
+        activateNextMission(progress);
+        handleMissionChain(progress);
+        checkSeedCopierAchievement(progress.getMember());
+
+        // [추가] 3. 활동 점수(Activity Score) 반영
+        updateActivityScore(progress.getMember());
+    }
+
+    // 레전드 미션(903) 달성 체크
+    public void checkLegendTier(Member member, int totalScore) {
+        if (totalScore >= 3600) { // Legend 기준 점수
+            missionRepository.findAllByTrackAndConditionType(MissionTrack.ACHIEVEMENT, MissionConditionType.REACH_LEGEND)
+                    .stream().findFirst().ifPresent(legendMission -> {
+                        missionProgressRepository.findByMemberAndMission(member, legendMission)
+                                .ifPresent(progress -> {
+                                    if (!progress.isCompleted()) {
+                                        progress.setCurrentValue(1);
+                                        checkMissionCompletion(progress); // 칭호 및 1억 지급
+                                    }
+                                });
+                    });
+        }
+    }
+
+    // applyForBankruptcy(B-6 잔류) 등 완료 판정 없이 보상만 지급하는 경로가 있어 public
+    public void distributeReward(Member member, Reward reward) {
+        if (reward == null) return;
+
+        if (reward.getMoneyAmount() > 0) {
+            accountRepository.findByMemberAndIsDefaultTrue(member)
+                    .ifPresentOrElse(
+                            acc -> {
+                                acc.increaseCash(BigDecimal.valueOf(reward.getMoneyAmount()));
+                                log.info("보상 지급: {}원", reward.getMoneyAmount());
+                            },
+                            () -> log.error("보상 지급 실패: 기본 계좌 없음 MemberId={}", member.getMemberId())
+                    );
+        }
+
+        if (reward.getTitleToGrant() != null) {
+            if (!memberTitleRepository.existsByMemberAndTitle(member, reward.getTitleToGrant())) {
+                member.addMemberTitle(MemberTitle.builder()
+                        .member(member)
+                        .title(reward.getTitleToGrant())
+                        .build());
+                log.info("칭호 지급: {}", reward.getTitleToGrant().getName());
+            }
+        }
+    }
+
+    /**
+     * 미션 완료 알림 이벤트 발행
+     */
+    private void publishMissionCompletedEvent(Member member, Mission mission, Reward reward) {
+        Long rewardId = reward != null ? reward.getId() : null;
+        Long moneyAmount = reward != null ? reward.getMoneyAmount() : 0L;
+        String titleName = (reward != null && reward.getTitleToGrant() != null)
+                ? reward.getTitleToGrant().getName()
+                : null;
+
+        MissionCompletedEvent event = new MissionCompletedEvent(
+                member.getMemberId(),
+                mission.getId(),
+                mission.getName(),
+                mission.getTrack(),
+                rewardId,
+                moneyAmount,
+                titleName
+        );
+
+        eventPublisher.publishEvent(event);
+        log.debug("미션 완료 이벤트 발행: memberId={}, missionId={}, missionName={}",
+                member.getMemberId(), mission.getId(), mission.getName());
+    }
+
+    private void activateNextMission(MissionProgress completedProgress) {
+        Mission completedMission = completedProgress.getMission();
+        Member member = completedProgress.getMember();
+
+        if (completedMission.getTrack() == MissionTrack.DAILY || completedMission.getTrack() == MissionTrack.ACHIEVEMENT) {
+            return;
+        }
+
+        Mission nextMission = completedMission.getNextMission();
+
+        if (nextMission != null) {
+            log.info("다음 미션 활성화: MissionId={}", nextMission.getId());
+            missionProgressRepository.findByMemberAndMission(member, nextMission)
+                    .orElseGet(() -> {
+                        MissionProgress newProgress = MissionProgress.builder()
+                                .member(member)
+                                .mission(nextMission)
+                                .status(MissionStatus.INACTIVE)
+                                .build();
+                        member.addMissionProgress(newProgress);
+                        return newProgress;
+                    }).activate();
+        } else if (completedMission.getType() == MissionType.ADVANCED) {
+            log.info("트랙 최종 완료: Track={}", completedMission.getTrack());
+            resetMissionTrack(member, completedMission.getTrack());
+        }
+    }
+
+    private void resetMissionTrack(Member member, MissionTrack track) {
+        log.info("트랙 초기화 시작: MemberId={}, Track={}", member.getMemberId(), track);
+        List<MissionProgress> progressList = missionProgressRepository.findAllByMemberAndMission_Track(member, track);
+
+        for (MissionProgress progress : progressList) {
+            progress.reset();
+            progress.deactivate();
+
+            // 트랙의 첫 번째 미션(중급 1단계)만 다시 활성화
+            if (progress.getMission().getType() == MissionType.INTERMEDIATE
+                    && missionTrackPolicy.isFirstMissionInTrack(progress.getMission().getId())) {
+                progress.activate();
+                log.info("트랙 첫 미션 재활성화: MissionId={}", progress.getMission().getId());
+            }
+        }
+    }
+
+    /**
+     * [신규] 활동 점수 업데이트
+     * - 미션 1개 완료 시 +10점 (예시)
+     * - 최대 점수(GoalValue)를 넘을 수 없음
+     */
+    private void updateActivityScore(Member member) {
+        // 활동 점수 트래커 조회 (ID 998 or Type=ACTIVITY_SCORE)
+        missionProgressRepository.findByMemberAndMissionTypeWithMission(member, MissionTrack.ACHIEVEMENT, MissionConditionType.ACTIVITY_SCORE)
+                .ifPresent(tracker -> {
+                    int maxScore = tracker.getMission().getGoalValue(); // 예: 1000점
+                    int currentScore = tracker.getCurrentValue();
+
+                    if (currentScore < maxScore) {
+                        int pointsToAdd = MISSION_COMPLETION_ACTIVITY_POINTS; // 미션 당 점수 (기획에 따라 조정)
+                        int newScore = Math.min(currentScore + pointsToAdd, maxScore);
+                        tracker.setCurrentValue(newScore);
+                        log.info("활동 점수 획득: Member={}, Current={}, Max={}", member.getName(), newScore, maxScore);
+                    }
+                });
+    }
+
+    /**
+     * [신규] 시드 복사기 (누적 미션 30회) 체크
+     */
+    private void checkSeedCopierAchievement(Member member) {
+        // 완료된 미션 총 개수 조회
+        long completedCount = missionProgressRepository.countByMemberAndStatus(member, MissionStatus.COMPLETED);
+
+        missionProgressRepository.findByMemberAndMissionTypeWithMission(member, MissionTrack.ACHIEVEMENT, MissionConditionType.TOTAL_MISSION_COUNT)
+                .ifPresent(progress -> {
+                    if (!progress.isCompleted()) {
+                        // 현재 완료 횟수를 진행도에 반영
+                        progress.setCurrentValue((int) completedCount);
+                        if (completedCount >= progress.getMission().getGoalValue()) { // 30회
+                            // 재귀 호출 방지를 위해 직접 complete 호출 (혹은 checkMissionCompletion 호출)
+                            // 여기서는 간단히 내부 로직 실행
+                            progress.complete();
+                            distributeReward(member, progress.getMission().getReward());
+                            log.info("'시드 복사기' 업적 달성! 총 완료 미션: {}개", completedCount);
+                        }
+                    }
+                });
+    }
+
+    private void handleMissionChain(MissionProgress completedProgress) {
+        Member member = completedProgress.getMember();
+        Mission mission = completedProgress.getMission();
+
+        // 일일 출석 완료 시 -> 연속 출석 업적 갱신
+        if (mission.getTrack() == MissionTrack.DAILY &&
+                mission.getConditionType() == MissionConditionType.LOGIN_COUNT) {
+            log.info("연쇄 업적 갱신 시도: 일일 출석 -> 연속 출석");
+            updateSpecificAchievement(member, MissionConditionType.LOGIN_STREAK, 1);
+        }
+    }
+
+    private void updateSpecificAchievement(Member member, MissionConditionType conditionType, int valueToIncrease) {
+        // 1. Optional -> List로 변경하여 해당 타입의 모든 업적 조회 (예: 3일, 7일, 30일 연속 등)
+        List<Mission> achievements = missionRepository
+                .findAllByTrackAndConditionType(MissionTrack.ACHIEVEMENT, conditionType);
+
+        if (achievements.isEmpty()) return;
+
+        // 2. 조회된 모든 업적에 대해 진행도 업데이트 반복
+        for (Mission achievement : achievements) {
+            MissionProgress achievementProgress = missionProgressRepository
+                    .findByMemberAndMission(member, achievement)
+                    .orElseGet(() -> {
+                        MissionProgress newProgress = MissionProgress.builder()
+                                .member(member)
+                                .mission(achievement)
+                                .status(MissionStatus.IN_PROGRESS)
+                                .build();
+                        member.addMissionProgress(newProgress);
+                        return newProgress;
+                    });
+
+            // 이미 완료된 업적은 패스
+            if (achievementProgress.getStatus() != MissionStatus.COMPLETED) {
+                achievementProgress.incrementProgress(valueToIncrease);
+                log.info("업적 미션({}) 갱신: MissionId={}, NewValue={}",
+                        achievement.getName(), achievement.getId(), achievementProgress.getCurrentValue());
+
+                checkMissionCompletion(achievementProgress);
+            }
+        }
+    }
+}

--- a/src/main/java/grit/stockIt/domain/mission/service/MissionService.java
+++ b/src/main/java/grit/stockIt/domain/mission/service/MissionService.java
@@ -56,6 +56,9 @@ public class MissionService {
     private final AccountStockRepository accountStockRepository; // [추가됨] 홀딩 여부 확인용
     private final StockRepository stockRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final MissionConditionEvaluator missionConditionEvaluator;
+    private final MissionProgressCalculator missionProgressCalculator;
+    private final MissionTrackPolicy missionTrackPolicy;
 
     private static final long JUNK_STOCK_MARKET_CAP_THRESHOLD = 100000000000L;
     private static final int MISSION_COMPLETION_ACTIVITY_POINTS = 10;
@@ -108,7 +111,7 @@ public class MissionService {
             }
 
             // 3. 그 외 조건 매칭 여부 확인 및 업데이트
-            if (isMissionConditionMatches(mission, event)) {
+            if (missionConditionEvaluator.isMissionConditionMatches(mission, event)) {
                 updateProgressValue(progress, mission, event);
             }
         }
@@ -150,7 +153,7 @@ public class MissionService {
                             member.getName(), profitInt, newTotalProfit);
 
                     // Legend 달성 체크 (현재 총 수익금 기반으로 점수 환산하여 체크)
-                    checkLegendTier(member, getActivityScore(member) + calculateScoreFromProfit(newTotalProfit));
+                    checkLegendTier(member, getActivityScore(member) + missionProgressCalculator.calculateScoreFromProfit(newTotalProfit));
                 });
     }
 
@@ -195,7 +198,7 @@ public class MissionService {
         int totalProfit = missionProgressRepository.findByMemberAndMissionTypeWithMission(member, MissionTrack.ACHIEVEMENT, MissionConditionType.SKILL_SCORE)
                 .map(MissionProgress::getCurrentValue).orElse(0);
 
-        int skillScore = calculateScoreFromProfit(totalProfit);
+        int skillScore = missionProgressCalculator.calculateScoreFromProfit(totalProfit);
         int totalScore = activityScore + skillScore;
 
         // 3. 티어 계산
@@ -385,8 +388,8 @@ public class MissionService {
         int goal = mission.getGoalValue();
 
         // A. 누적형 (카운트 증가) - 기존과 동일
-        if (isCumulativeType(type)) {
-            int valueToIncrease = calculateIncreaseValue(type, event);
+        if (missionConditionEvaluator.isCumulativeType(type)) {
+            int valueToIncrease = missionProgressCalculator.calculateIncreaseValue(type, event);
             if (valueToIncrease > 0) {
                 progress.incrementProgress(valueToIncrease);
                 log.info("미션(누적) 갱신: MissionId={}, Added={}, Current={}",
@@ -395,8 +398,8 @@ public class MissionService {
             }
         }
         // B. 달성형 (임계값 돌파 / 최고 기록 갱신) - [수정됨]
-        else if (isThresholdType(type)) {
-            int eventValue = calculateThresholdValue(type, event);
+        else if (missionConditionEvaluator.isThresholdType(type)) {
+            int eventValue = missionProgressCalculator.calculateThresholdValue(type, event);
 
             // 현재 기록보다 더 높은 기록이 나오면 갱신 (Best Record)
             if (eventValue > progress.getCurrentValue()) {
@@ -413,136 +416,6 @@ public class MissionService {
                 }
             }
         }
-    }
-
-
-    private boolean isCumulativeType(MissionConditionType type) {
-        return switch (type) {
-            case TRADE_COUNT, BUY_COUNT, SELL_COUNT,
-                 BUY_AMOUNT, SELL_AMOUNT,
-                 TOTAL_TRADE_AMOUNT, DAILY_PROFIT_COUNT, DAILY_TRADE_COUNT,
-
-                 PROFIT_RATE // [추가] 수익률도 이제 차곡차곡 쌓는 '누적형'입니다.
-                    -> true;
-
-            default -> false;
-        };
-    }
-
-    private boolean isThresholdType(MissionConditionType type) {
-        // HOLDING_DAYS는 스케줄러가 처리하므로 제외
-        return switch (type) {
-            case PROFIT_AMOUNT -> true;
-            default -> false;
-        };
-    }
-
-    private int calculateIncreaseValue(MissionConditionType type, TradeCompletionEvent event) {
-        return switch (type) {
-            case TRADE_COUNT, BUY_COUNT, SELL_COUNT, DAILY_TRADE_COUNT -> 1;
-
-            case BUY_AMOUNT, SELL_AMOUNT, TOTAL_TRADE_AMOUNT ->
-                    event.getFilledAmount().intValue();
-
-            case DAILY_PROFIT_COUNT -> {
-                // 매도(SELL)이면서, 체결가가 평단가보다 크면 익절 (1회 증가)
-                boolean isSell = event.getOrderMethod() == OrderMethod.SELL;
-                boolean isProfit = event.getFilledPrice().compareTo(event.getBuyAveragePrice()) > 0;
-                yield (isSell && isProfit) ? 1 : 0;
-            }
-
-            // [신규 이동] 수익률 누적 계산
-            case PROFIT_RATE -> {
-                if (event.getOrderMethod() != OrderMethod.SELL) yield 0;
-
-                BigDecimal sellPrice = event.getFilledPrice();
-                BigDecimal avgBuyPrice = event.getBuyAveragePrice();
-
-                if (avgBuyPrice == null || avgBuyPrice.compareTo(BigDecimal.ZERO) == 0) {
-                    yield 0;
-                }
-
-                // 수익률 공식: ((매도가 - 평단가) / 평단가) * 100
-                BigDecimal profitRate = sellPrice.subtract(avgBuyPrice)
-                        .divide(avgBuyPrice, 4, java.math.RoundingMode.HALF_UP)
-                        .multiply(BigDecimal.valueOf(100));
-
-                // 예: 5.5% 수익 -> 6점 증가 (반올림)
-                // 예: -10% 손실 -> -10점 (진행도 깎임) -> 원치 않으시면 Math.max(0, ...) 처리 필요
-                yield profitRate.setScale(0, java.math.RoundingMode.HALF_UP).intValue();
-            }
-
-            default -> 0;
-        };
-    }
-
-    // [수정] 값 계산 시 반올림 적용 (선택 사항이나 권장)
-    private int calculateThresholdValue(MissionConditionType type, TradeCompletionEvent event) {
-        // 매도가 아니면 수익률/수익금 계산 불가
-        if (event.getOrderMethod() != OrderMethod.SELL) return 0;
-
-        // 1. 수익률 (PROFIT_RATE) 계산
-        if (type == MissionConditionType.PROFIT_RATE) {
-            // [수정] event.getProfitRate()를 신뢰하지 않고 직접 계산 로직을 우선 사용
-
-            BigDecimal sellPrice = event.getFilledPrice();     // 매도 체결가
-            BigDecimal avgBuyPrice = event.getBuyAveragePrice(); // 평단가
-
-            // 평단가가 0이거나 없으면 계산 불가 (0 리턴)
-            if (avgBuyPrice == null || avgBuyPrice.compareTo(BigDecimal.ZERO) == 0) {
-                log.warn("수익률 계산 실패: 평단가가 0입니다. StockCode={}", event.getStockCode());
-                return 0;
-            }
-
-            // 공식: ((매도가 - 평단가) / 평단가) * 100
-            // 예: 매도가 10500, 평단가 10000 -> (500 / 10000) * 100 = 5%
-            BigDecimal profitRate = sellPrice.subtract(avgBuyPrice)
-                    .divide(avgBuyPrice, 4, java.math.RoundingMode.HALF_UP) // 소수점 4자리까지 확보 (0.0500)
-                    .multiply(BigDecimal.valueOf(100)); // 백분율 변환 (5.00)
-
-            // 로그로 계산 과정 출력 (디버깅용)
-            log.info("수익률 계산: ({} - {}) / {} * 100 = {}%",
-                    sellPrice, avgBuyPrice, avgBuyPrice, profitRate);
-
-            // 소수점 반올림하여 정수로 반환 (예: 4.9% -> 5%, 4.4% -> 4%)
-            return profitRate.setScale(0, java.math.RoundingMode.HALF_UP).intValue();
-        }
-
-        // 2. 수익금 (PROFIT_AMOUNT) 계산
-        if (type == MissionConditionType.PROFIT_AMOUNT) {
-            // 수익금은 직접 계산: (판 금액 - (평단가 * 수량))
-            BigDecimal totalSellAmount = event.getFilledAmount();
-            BigDecimal totalBuyCost = event.getBuyAveragePrice()
-                    .multiply(BigDecimal.valueOf(event.getFilledQuantity()));
-
-            BigDecimal profitAmount = totalSellAmount.subtract(totalBuyCost);
-
-            return profitAmount.intValue();
-        }
-
-        return 0;
-    }
-
-    private boolean isMissionConditionMatches(Mission mission, TradeCompletionEvent event) {
-        MissionConditionType type = mission.getConditionType();
-        OrderMethod method = event.getOrderMethod();
-
-        // 매수 전용
-        if (type == MissionConditionType.BUY_COUNT || type == MissionConditionType.BUY_AMOUNT)
-            return method == OrderMethod.BUY;
-
-        // 매도 전용
-        if (type == MissionConditionType.SELL_COUNT || type == MissionConditionType.SELL_AMOUNT ||
-                type == MissionConditionType.PROFIT_RATE || type == MissionConditionType.DAILY_PROFIT_COUNT ||
-                type == MissionConditionType.PROFIT_AMOUNT)
-            return method == OrderMethod.SELL;
-
-        // 공통
-        if (type == MissionConditionType.TRADE_COUNT || type == MissionConditionType.TOTAL_TRADE_AMOUNT ||
-                type == MissionConditionType.DAILY_TRADE_COUNT)
-            return true;
-
-        return false;
     }
 
     // ... 기존 메서드들 ...
@@ -758,16 +631,6 @@ public class MissionService {
         return bankruptcyProgress.getMission().getReward();
     }
 
-    /**
-     * [신규] 수익금을 점수로 환산하는 헬퍼 메서드
-     * - 공식: Score = sqrt(max(0, TotalProfit))
-     * - 수익금이 마이너스(손실 중)라면 0점으로 처리
-     */
-    private int calculateScoreFromProfit(int totalProfit) {
-        if (totalProfit <= 0) return 0;
-        return (int) Math.sqrt(totalProfit / 10.0);
-    }
-
     private void distributeReward(Member member, Reward reward) {
         if (reward == null) return;
 
@@ -896,17 +759,12 @@ public class MissionService {
             progress.deactivate();
 
             // 트랙의 첫 번째 미션(중급 1단계)만 다시 활성화
-            if (progress.getMission().getType() == MissionType.INTERMEDIATE && isFirstMissionInTrack(progress.getMission())) {
+            if (progress.getMission().getType() == MissionType.INTERMEDIATE
+                    && missionTrackPolicy.isFirstMissionInTrack(progress.getMission().getId())) {
                 progress.activate();
                 log.info("트랙 첫 미션 재활성화: MissionId={}", progress.getMission().getId());
             }
         }
-    }
-
-    private boolean isFirstMissionInTrack(Mission mission) {
-        long id = mission.getId();
-        // data.sql 기준 첫 미션 ID (201: 단타, 301: 스윙, 401: 장기)
-        return id == 201 || id == 301 || id == 401;
     }
 
     @Transactional
@@ -959,7 +817,7 @@ public class MissionService {
                 initialStatus = MissionStatus.IN_PROGRESS;
             }
             // 2. 트랙 미션 -> 첫 번째 미션만 진행 중
-            else if (isFirstMissionInTrack(mission)) {
+            else if (missionTrackPolicy.isFirstMissionInTrack(mission.getId())) {
                 initialStatus = MissionStatus.IN_PROGRESS;
             }
 

--- a/src/main/java/grit/stockIt/domain/mission/service/MissionService.java
+++ b/src/main/java/grit/stockIt/domain/mission/service/MissionService.java
@@ -15,16 +15,11 @@ import grit.stockIt.domain.mission.enums.MissionTrack;
 import grit.stockIt.domain.mission.enums.MissionType;
 import grit.stockIt.domain.mission.repository.MissionProgressRepository;
 import grit.stockIt.domain.mission.repository.MissionRepository;
-import grit.stockIt.domain.notification.event.MissionCompletedEvent;
 import grit.stockIt.domain.order.entity.OrderMethod;
 import grit.stockIt.domain.order.event.TradeCompletionEvent;
-import grit.stockIt.domain.title.entity.MemberTitle;
-import grit.stockIt.domain.title.entity.Title;
-import grit.stockIt.domain.title.repository.MemberTitleRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import grit.stockIt.domain.stock.entity.Stock;
@@ -47,17 +42,15 @@ public class MissionService {
     private final MemberRepository memberRepository;
     private final MissionRepository missionRepository;
     private final MissionProgressRepository missionProgressRepository;
-    private final MemberTitleRepository memberTitleRepository;
     private final AccountRepository accountRepository;
     private final AccountStockRepository accountStockRepository; // [추가됨] 홀딩 여부 확인용
     private final StockRepository stockRepository;
-    private final ApplicationEventPublisher eventPublisher;
     private final MissionConditionEvaluator missionConditionEvaluator;
     private final MissionProgressCalculator missionProgressCalculator;
     private final MissionTrackPolicy missionTrackPolicy;
+    private final MissionRewardService missionRewardService;
 
     private static final long JUNK_STOCK_MARKET_CAP_THRESHOLD = 100000000000L;
-    private static final int MISSION_COMPLETION_ACTIVITY_POINTS = 10;
     /**
      * [1] (이벤트 수신) 거래 이벤트 발생 시 미션 진행도 업데이트
      * - 일반 미션 갱신 로직
@@ -149,25 +142,10 @@ public class MissionService {
                             member.getName(), profitInt, newTotalProfit);
 
                     // Legend 달성 체크 (현재 총 수익금 기반으로 점수 환산하여 체크)
-                    checkLegendTier(member, getActivityScore(member) + missionProgressCalculator.calculateScoreFromProfit(newTotalProfit));
+                    missionRewardService.checkLegendTier(member, getActivityScore(member) + missionProgressCalculator.calculateScoreFromProfit(newTotalProfit));
                 });
     }
 
-    // 레전드 미션(903) 달성 체크
-    private void checkLegendTier(Member member, int totalScore) {
-        if (totalScore >= 3600) { // Legend 기준 점수
-            missionRepository.findAllByTrackAndConditionType(MissionTrack.ACHIEVEMENT, MissionConditionType.REACH_LEGEND)
-                    .stream().findFirst().ifPresent(legendMission -> {
-                        missionProgressRepository.findByMemberAndMission(member, legendMission)
-                                .ifPresent(progress -> {
-                                    if (!progress.isCompleted()) {
-                                        progress.setCurrentValue(1);
-                                        checkMissionCompletion(progress); // 칭호 및 1억 지급
-                                    }
-                                });
-                    });
-        }
-    }
     /**
      * [Helper] 현재 활동 점수(Activity Score) 조회
      * - 트래커 미션(998번)의 현재 값을 가져옴
@@ -224,7 +202,7 @@ public class MissionService {
                 .ifPresent(progress -> {
                     if (!progress.isCompleted()) {
                         progress.setCurrentValue(value);
-                        checkMissionCompletion(progress);
+                        missionRewardService.checkMissionCompletion(progress);
                     }
                 });
     }
@@ -246,7 +224,7 @@ public class MissionService {
                 progress.incrementProgress(1);
                 log.info("홀딩 미션 +1일 증가: MemberId={}, MissionId={}, NewValue={}",
                         member.getMemberId(), progress.getMission().getId(), progress.getCurrentValue());
-                checkMissionCompletion(progress);
+                missionRewardService.checkMissionCompletion(progress);
             }
         }
     }
@@ -263,7 +241,7 @@ public class MissionService {
                 progress.incrementProgress(valueToIncrease);
                 log.info("미션(누적) 갱신: MissionId={}, Added={}, Current={}",
                         mission.getId(), valueToIncrease, progress.getCurrentValue());
-                checkMissionCompletion(progress);
+                missionRewardService.checkMissionCompletion(progress);
             }
         }
         // B. 달성형 (임계값 돌파 / 최고 기록 갱신) - [수정됨]
@@ -281,7 +259,7 @@ public class MissionService {
 
                 // 목표 달성 여부 체크
                 if (eventValue >= goal) {
-                    checkMissionCompletion(progress);
+                    missionRewardService.checkMissionCompletion(progress);
                 }
             }
         }
@@ -308,80 +286,6 @@ public class MissionService {
 
         log.info("총 {}건의 연속 출석 기록이 일괄 초기화되었습니다.", updatedCount);
     }
-
-    // --- [공통 로직] 완료 처리, 보상, 초기화 ---
-
-    public void checkMissionCompletion(MissionProgress progress) {
-        if (progress.getStatus() == MissionStatus.COMPLETED || !progress.isCompleted()) {
-            return;
-        }
-
-        progress.complete();
-        log.info("미션 완료: MemberId={}, MissionId={}", progress.getMember().getMemberId(), progress.getMission().getId());
-
-        Mission mission = progress.getMission();
-        Reward reward = mission.getReward();
-        
-        // 보상 지급
-        distributeReward(progress.getMember(), reward);
-        
-        // 출석 미션은 알림 발송 제외
-        if (mission.getConditionType() != MissionConditionType.LOGIN_COUNT) {
-            // 미션 완료 알림 이벤트 발행
-            publishMissionCompletedEvent(progress.getMember(), mission, reward);
-        }
-        
-        activateNextMission(progress);
-        handleMissionChain(progress);
-        checkSeedCopierAchievement(progress.getMember());
-
-        // [추가] 3. 활동 점수(Activity Score) 반영
-        updateActivityScore(progress.getMember());
-    }
-    /**
-     * [신규] 활동 점수 업데이트
-     * - 미션 1개 완료 시 +10점 (예시)
-     * - 최대 점수(GoalValue)를 넘을 수 없음
-     */
-    private void updateActivityScore(Member member) {
-        // 활동 점수 트래커 조회 (ID 998 or Type=ACTIVITY_SCORE)
-        missionProgressRepository.findByMemberAndMissionTypeWithMission(member, MissionTrack.ACHIEVEMENT, MissionConditionType.ACTIVITY_SCORE)
-                .ifPresent(tracker -> {
-                    int maxScore = tracker.getMission().getGoalValue(); // 예: 1000점
-                    int currentScore = tracker.getCurrentValue();
-
-                    if (currentScore < maxScore) {
-                        int pointsToAdd = MISSION_COMPLETION_ACTIVITY_POINTS; // 미션 당 점수 (기획에 따라 조정)
-                        int newScore = Math.min(currentScore + pointsToAdd, maxScore);
-                        tracker.setCurrentValue(newScore);
-                        log.info("활동 점수 획득: Member={}, Current={}, Max={}", member.getName(), newScore, maxScore);
-                    }
-                });
-    }
-    /**
-     * [신규] 시드 복사기 (누적 미션 30회) 체크
-     */
-    private void checkSeedCopierAchievement(Member member) {
-        // 완료된 미션 총 개수 조회
-        long completedCount = missionProgressRepository.countByMemberAndStatus(member, MissionStatus.COMPLETED);
-
-        missionProgressRepository.findByMemberAndMissionTypeWithMission(member, MissionTrack.ACHIEVEMENT, MissionConditionType.TOTAL_MISSION_COUNT)
-                .ifPresent(progress -> {
-                    if (!progress.isCompleted()) {
-                        // 현재 완료 횟수를 진행도에 반영
-                        progress.setCurrentValue((int) completedCount);
-                        if (completedCount >= progress.getMission().getGoalValue()) { // 30회
-                            // 재귀 호출 방지를 위해 직접 complete 호출 (혹은 checkMissionCompletion 호출)
-                            // 여기서는 간단히 내부 로직 실행
-                            progress.complete();
-                            distributeReward(member, progress.getMission().getReward());
-                            log.info("'시드 복사기' 업적 달성! 총 완료 미션: {}개", completedCount);
-                        }
-                    }
-                });
-    }
-
-
 
     /**
      * [신규] 인생 2회차 (파산 신청) API 로직
@@ -423,7 +327,7 @@ public class MissionService {
 
         bankruptcyProgress.setCurrentValue(bankruptcyProgress.getMission().getGoalValue()); // 조건 충족 표시
         bankruptcyProgress.complete();
-        distributeReward(member, bankruptcyProgress.getMission().getReward());
+        missionRewardService.distributeReward(member, bankruptcyProgress.getMission().getReward());
 
         log.info("파산 신청 승인! 구조지원금 지급 완료. Member={}", member.getName());
 
@@ -436,56 +340,6 @@ public class MissionService {
 
         log.info("파산 승인 및 티어 초기화 완료: Member={}", member.getName());
         return bankruptcyProgress.getMission().getReward();
-    }
-
-    private void distributeReward(Member member, Reward reward) {
-        if (reward == null) return;
-
-        if (reward.getMoneyAmount() > 0) {
-            accountRepository.findByMemberAndIsDefaultTrue(member)
-                    .ifPresentOrElse(
-                            acc -> {
-                                acc.increaseCash(BigDecimal.valueOf(reward.getMoneyAmount()));
-                                log.info("보상 지급: {}원", reward.getMoneyAmount());
-                            },
-                            () -> log.error("보상 지급 실패: 기본 계좌 없음 MemberId={}", member.getMemberId())
-                    );
-        }
-
-        if (reward.getTitleToGrant() != null) {
-            if (!memberTitleRepository.existsByMemberAndTitle(member, reward.getTitleToGrant())) {
-                member.addMemberTitle(MemberTitle.builder()
-                        .member(member)
-                        .title(reward.getTitleToGrant())
-                        .build());
-                log.info("칭호 지급: {}", reward.getTitleToGrant().getName());
-            }
-        }
-    }
-
-    /**
-     * 미션 완료 알림 이벤트 발행
-     */
-    private void publishMissionCompletedEvent(Member member, Mission mission, Reward reward) {
-        Long rewardId = reward != null ? reward.getId() : null;
-        Long moneyAmount = reward != null ? reward.getMoneyAmount() : 0L;
-        String titleName = (reward != null && reward.getTitleToGrant() != null) 
-                ? reward.getTitleToGrant().getName() 
-                : null;
-
-        MissionCompletedEvent event = new MissionCompletedEvent(
-                member.getMemberId(),
-                mission.getId(),
-                mission.getName(),
-                mission.getTrack(),
-                rewardId,
-                moneyAmount,
-                titleName
-        );
-
-        eventPublisher.publishEvent(event);
-        log.debug("미션 완료 이벤트 발행: memberId={}, missionId={}, missionName={}", 
-                member.getMemberId(), mission.getId(), mission.getName());
     }
 
     /**
@@ -524,52 +378,7 @@ public class MissionService {
             if (!progress.isCompleted()) {
                 log.info("랭커 등극! 칭호 지급: MemberId={}", memberId);
                 progress.setCurrentValue(10); // 목표치(10) 달성 처리
-                checkMissionCompletion(progress); // 보상(칭호) 지급 및 완료 처리
-            }
-        }
-    }
-
-    private void activateNextMission(MissionProgress completedProgress) {
-        Mission completedMission = completedProgress.getMission();
-        Member member = completedProgress.getMember();
-
-        if (completedMission.getTrack() == MissionTrack.DAILY || completedMission.getTrack() == MissionTrack.ACHIEVEMENT) {
-            return;
-        }
-
-        Mission nextMission = completedMission.getNextMission();
-
-        if (nextMission != null) {
-            log.info("다음 미션 활성화: MissionId={}", nextMission.getId());
-            missionProgressRepository.findByMemberAndMission(member, nextMission)
-                    .orElseGet(() -> {
-                        MissionProgress newProgress = MissionProgress.builder()
-                                .member(member)
-                                .mission(nextMission)
-                                .status(MissionStatus.INACTIVE)
-                                .build();
-                        member.addMissionProgress(newProgress);
-                        return newProgress;
-                    }).activate();
-        } else if (completedMission.getType() == MissionType.ADVANCED) {
-            log.info("트랙 최종 완료: Track={}", completedMission.getTrack());
-            resetMissionTrack(member, completedMission.getTrack());
-        }
-    }
-
-    public void resetMissionTrack(Member member, MissionTrack track) {
-        log.info("트랙 초기화 시작: MemberId={}, Track={}", member.getMemberId(), track);
-        List<MissionProgress> progressList = missionProgressRepository.findAllByMemberAndMission_Track(member, track);
-
-        for (MissionProgress progress : progressList) {
-            progress.reset();
-            progress.deactivate();
-
-            // 트랙의 첫 번째 미션(중급 1단계)만 다시 활성화
-            if (progress.getMission().getType() == MissionType.INTERMEDIATE
-                    && missionTrackPolicy.isFirstMissionInTrack(progress.getMission().getId())) {
-                progress.activate();
-                log.info("트랙 첫 미션 재활성화: MissionId={}", progress.getMission().getId());
+                missionRewardService.checkMissionCompletion(progress); // 보상(칭호) 지급 및 완료 처리
             }
         }
     }
@@ -653,7 +462,7 @@ public class MissionService {
         }
 
         attendanceProgress.incrementProgress(1);
-        checkMissionCompletion(attendanceProgress);
+        missionRewardService.checkMissionCompletion(attendanceProgress);
         return attendanceProgress.getMission().getReward();
     }
 
@@ -674,7 +483,7 @@ public class MissionService {
                     if (progress.getStatus() != MissionStatus.COMPLETED && !progress.isCompleted()) {
                         progress.incrementProgress(1);
                         log.info("일일 미션({}) 진행도 갱신: MemberId={}", type, member.getMemberId());
-                        checkMissionCompletion(progress);
+                        missionRewardService.checkMissionCompletion(progress);
                     }
                 });
     }
@@ -684,50 +493,6 @@ public class MissionService {
     private Member getMemberByEmail(String email) {
         return memberRepository.findByEmail(email)
                 .orElseThrow(() -> new EntityNotFoundException("회원을 찾을 수 없습니다. Email: " + email));
-    }
-
-    private void handleMissionChain(MissionProgress completedProgress) {
-        Member member = completedProgress.getMember();
-        Mission mission = completedProgress.getMission();
-
-        // 일일 출석 완료 시 -> 연속 출석 업적 갱신
-        if (mission.getTrack() == MissionTrack.DAILY &&
-                mission.getConditionType() == MissionConditionType.LOGIN_COUNT) {
-            log.info("연쇄 업적 갱신 시도: 일일 출석 -> 연속 출석");
-            updateSpecificAchievement(member, MissionConditionType.LOGIN_STREAK, 1);
-        }
-    }
-
-    private void updateSpecificAchievement(Member member, MissionConditionType conditionType, int valueToIncrease) {
-        // 1. Optional -> List로 변경하여 해당 타입의 모든 업적 조회 (예: 3일, 7일, 30일 연속 등)
-        List<Mission> achievements = missionRepository
-                .findAllByTrackAndConditionType(MissionTrack.ACHIEVEMENT, conditionType);
-
-        if (achievements.isEmpty()) return;
-
-        // 2. 조회된 모든 업적에 대해 진행도 업데이트 반복
-        for (Mission achievement : achievements) {
-            MissionProgress achievementProgress = missionProgressRepository
-                    .findByMemberAndMission(member, achievement)
-                    .orElseGet(() -> {
-                        MissionProgress newProgress = MissionProgress.builder()
-                                .member(member)
-                                .mission(achievement)
-                                .status(MissionStatus.IN_PROGRESS)
-                                .build();
-                        member.addMissionProgress(newProgress);
-                        return newProgress;
-                    });
-
-            // 이미 완료된 업적은 패스
-            if (achievementProgress.getStatus() != MissionStatus.COMPLETED) {
-                achievementProgress.incrementProgress(valueToIncrease);
-                log.info("업적 미션({}) 갱신: MissionId={}, NewValue={}",
-                        achievement.getName(), achievement.getId(), achievementProgress.getCurrentValue());
-
-                checkMissionCompletion(achievementProgress);
-            }
-        }
     }
 
     // findDailyAttendanceMission 제거 (직접 쿼리 사용으로 대체됨)

--- a/src/main/java/grit/stockIt/domain/mission/service/MissionService.java
+++ b/src/main/java/grit/stockIt/domain/mission/service/MissionService.java
@@ -3,7 +3,7 @@ package grit.stockIt.domain.mission.service;
 import grit.stockIt.domain.account.entity.Account;
 import grit.stockIt.domain.account.entity.AccountStock;
 import grit.stockIt.domain.account.repository.AccountRepository;
-import grit.stockIt.domain.account.repository.AccountStockRepository; // [추가]
+import grit.stockIt.domain.account.repository.AccountStockRepository;
 import grit.stockIt.domain.member.entity.Member;
 import grit.stockIt.domain.member.repository.MemberRepository;
 import grit.stockIt.domain.mission.entity.Mission;
@@ -27,6 +27,12 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+/**
+ * [B-6 잔류] 회원 액션 전담 서비스.
+ * - 신규 회원 미션 초기화, 출석 보상, 파산 신청, 일일 단순 미션(리포트 조회·포트폴리오 분석) 처리.
+ * - 거래 이벤트 진행도는 MissionProgressService, 자정 배치는 MissionBatchService,
+ *   조회는 MissionQueryService, 완료 판정·보상은 MissionRewardService가 담당한다.
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -38,7 +44,7 @@ public class MissionService {
     private final MissionRepository missionRepository;
     private final MissionProgressRepository missionProgressRepository;
     private final AccountRepository accountRepository;
-    private final AccountStockRepository accountStockRepository; // [추가됨] 홀딩 여부 확인용
+    private final AccountStockRepository accountStockRepository; // 파산 신청 시 보유 주식 평가용
     private final MissionTrackPolicy missionTrackPolicy;
     private final MissionRewardService missionRewardService;
 

--- a/src/main/java/grit/stockIt/domain/mission/service/MissionService.java
+++ b/src/main/java/grit/stockIt/domain/mission/service/MissionService.java
@@ -6,10 +6,6 @@ import grit.stockIt.domain.account.repository.AccountRepository;
 import grit.stockIt.domain.account.repository.AccountStockRepository; // [추가]
 import grit.stockIt.domain.member.entity.Member;
 import grit.stockIt.domain.member.repository.MemberRepository;
-import grit.stockIt.domain.mission.dto.MemberTitleResponse;
-import grit.stockIt.domain.mission.dto.MissionDashboardResponse;
-import grit.stockIt.domain.mission.dto.MissionListResponse;
-import grit.stockIt.domain.mission.dto.UserTierStatusResponse;
 import grit.stockIt.domain.mission.entity.Mission;
 import grit.stockIt.domain.mission.entity.MissionProgress;
 import grit.stockIt.domain.mission.entity.Reward;
@@ -186,133 +182,6 @@ public class MissionService {
                 .map(MissionProgress::getCurrentValue)
                 .orElse(0);
     }
-    @Transactional(readOnly = true)
-    public UserTierStatusResponse getTierInfo(String email) {
-        Member member = getMemberByEmail(email);
-
-        // 1. 활동 점수
-        int activityScore = missionProgressRepository.findByMemberAndMissionTypeWithMission(member, MissionTrack.ACHIEVEMENT, MissionConditionType.ACTIVITY_SCORE)
-                .map(MissionProgress::getCurrentValue).orElse(0);
-
-        // 2. 실력 점수
-        int totalProfit = missionProgressRepository.findByMemberAndMissionTypeWithMission(member, MissionTrack.ACHIEVEMENT, MissionConditionType.SKILL_SCORE)
-                .map(MissionProgress::getCurrentValue).orElse(0);
-
-        int skillScore = missionProgressCalculator.calculateScoreFromProfit(totalProfit);
-        int totalScore = activityScore + skillScore;
-
-        // 3. 티어 계산
-        String currentTier;
-        String nextTier;
-        int nextTierScore;        // 다음 티어 승급 점수 (목표)
-        int currentTierStartScore; // [신규] 현재 티어 시작 점수 (진행도 계산용)
-
-        if (totalScore < 800) {
-            currentTier = "BRONZE 1";
-            nextTier = "BRONZE 2";
-            currentTierStartScore = 0;   // 0 ~ 799
-            nextTierScore = 800;
-        } else if (totalScore < 1000) {
-            currentTier = "BRONZE 2";
-            nextTier = "BRONZE 3";
-            currentTierStartScore = 800; // 800 ~ 999
-            nextTierScore = 1000;
-        } else if (totalScore < 1200) {
-            currentTier = "BRONZE 3";
-            nextTier = "SILVER 1";
-            currentTierStartScore = 1000; // 1000 ~ 1199
-            nextTierScore = 1200;
-        } else if (totalScore < 1400) {
-            currentTier = "SILVER 1";
-            nextTier = "SILVER 2";
-            currentTierStartScore = 1200; // 1200 ~ 1399 (신규 유저 시작 구간)
-            nextTierScore = 1400;
-        } else if (totalScore < 1600) {
-            currentTier = "SILVER 2";
-            nextTier = "SILVER 3";
-            currentTierStartScore = 1400;
-            nextTierScore = 1600;
-        } else if (totalScore < 1800) {
-            currentTier = "SILVER 3";
-            nextTier = "GOLD 1";
-            currentTierStartScore = 1600;
-            nextTierScore = 1800;
-        } else if (totalScore < 2000) {
-            currentTier = "GOLD 1";
-            nextTier = "GOLD 2";
-            currentTierStartScore = 1800;
-            nextTierScore = 2000;
-        } else if (totalScore < 2200) {
-            currentTier = "GOLD 2";
-            nextTier = "GOLD 3";
-            currentTierStartScore = 2000;
-            nextTierScore = 2200;
-        } else if (totalScore < 2400) {
-            currentTier = "GOLD 3";
-            nextTier = "MASTER 1";
-            currentTierStartScore = 2200;
-            nextTierScore = 2400;
-        } else if (totalScore < 2600) {
-            currentTier = "MASTER 1";
-            nextTier = "MASTER 2";
-            currentTierStartScore = 2400;
-            nextTierScore = 2600;
-        } else if (totalScore < 2800) {
-            currentTier = "MASTER 2";
-            nextTier = "MASTER 3";
-            currentTierStartScore = 2600;
-            nextTierScore = 2800;
-        } else if (totalScore < 3000) {
-            currentTier = "MASTER 3";
-            nextTier = "GRANDMASTER 1";
-            currentTierStartScore = 2800;
-            nextTierScore = 3000;
-        } else if (totalScore < 3200) {
-            currentTier = "GRANDMASTER 1";
-            nextTier = "GRANDMASTER 2";
-            currentTierStartScore = 3000;
-            nextTierScore = 3200;
-        } else if (totalScore < 3400) {
-            currentTier = "GRANDMASTER 2";
-            nextTier = "GRANDMASTER 3";
-            currentTierStartScore = 3200;
-            nextTierScore = 3400;
-        } else if (totalScore < 3600) {
-            currentTier = "GRANDMASTER 3";
-            nextTier = "LEGEND";
-            currentTierStartScore = 3400;
-            nextTierScore = 3600;
-        } else {
-            currentTier = "LEGEND";
-            nextTier = "MAX";
-            currentTierStartScore = 3600;
-            nextTierScore = totalScore; // Legend는 목표치가 없으므로 현재 점수와 동일시
-        }
-
-        // 4. 진행도 계산 (현재 구간 내에서의 %)
-        double progress = 0.0;
-        if (!"MAX".equals(nextTier)) {
-            // 공식: (현재점수 - 시작점수) / (목표점수 - 시작점수) * 100
-            double gainedInCurrentTier = (double) (totalScore - currentTierStartScore);
-            double rangeOfCurrentTier = (double) (nextTierScore - currentTierStartScore);
-
-            if (rangeOfCurrentTier > 0) {
-                progress = (gainedInCurrentTier / rangeOfCurrentTier) * 100.0;
-            }
-        } else {
-            progress = 100.0;
-        }
-
-        return UserTierStatusResponse.builder()
-                .currentTier(currentTier)
-                .nextTier(nextTier)
-                .totalScore(totalScore)
-                .activityScore(activityScore)
-                .skillScore(skillScore)
-                .scoreToNextTier(nextTierScore - totalScore)
-                .progressPercentage(progress)
-                .build();
-    }
     /**
      * [신규] 특수 조건 업적 처리
      * - 달콤한 첫입 (FIRST_PROFIT)
@@ -438,68 +307,6 @@ public class MissionService {
         );
 
         log.info("총 {}건의 연속 출석 기록이 일괄 초기화되었습니다.", updatedCount);
-    }
-    // 대시보드용 요약 정보 조회
-    @Transactional(readOnly = true)
-    public MissionDashboardResponse getMissionDashboard(String email) {
-        Member member = getMemberByEmail(email);
-
-        // 1. 연속 출석 일수 (업적 중 LOGIN_STREAK 타입의 현재 진행도 조회)
-// 7일, 15일, 30일 업적 미션들과 충돌하지 않음
-        int streak = missionProgressRepository
-                .findTopByMemberAndConditionOrderByGoalDesc(member, MissionTrack.ACHIEVEMENT, MissionConditionType.LOGIN_STREAK)
-                .map(MissionProgress::getCurrentValue)
-                .orElse(0); // 트래커 미션이 아직 생성 안 됐으면 0일
-
-        // 2. 남은 일일 미션 개수 (DAILY 트랙 중, 완료되지 않은 것의 개수)
-        List<MissionProgress> dailyMissions = missionProgressRepository.findAllByMemberAndMission_Track(member, MissionTrack.DAILY);
-        int remaining = (int) dailyMissions.stream()
-                .filter(mp -> !mp.isCompleted())
-                .count();
-
-        return MissionDashboardResponse.builder()
-                .consecutiveAttendanceDays(streak)
-                .remainingDailyMissions(remaining)
-                .build();
-    }
-
-    // 트랙별 미션 리스트 조회 (Enum 변환을 통한 안정성 확보)
-    @Transactional(readOnly = true)
-    public List<MissionListResponse> getMissionsByTrack(String email, String trackName) {
-        Member member = getMemberByEmail(email);
-        List<MissionProgress> allProgress = missionProgressRepository.findByMemberWithMissionAndReward(member);
-
-        // 1. "ALL"인 경우 전체 반환 (대소문자 무시: all, ALL 등)
-        if (trackName == null || "ALL".equalsIgnoreCase(trackName)) {
-            return allProgress.stream()
-                    .map(MissionListResponse::new)
-                    .collect(Collectors.toList());
-        }
-
-        // 2. 특정 트랙 필터링 (Enum 변환 시도)
-        try {
-            // 입력값을 대문자로 변환하여 Enum 매핑 (daily -> DAILY)
-            MissionTrack filterTrack = MissionTrack.valueOf(trackName.toUpperCase());
-
-            return allProgress.stream()
-                    .filter(mp -> mp.getMission().getTrack() == filterTrack) // Enum 타입 비교 (==)
-                    .map(MissionListResponse::new)
-                    .collect(Collectors.toList());
-
-        } catch (IllegalArgumentException e) {
-            // 정의되지 않은 트랙 이름이 들어온 경우 (예: "ABCD")
-            log.warn("유효하지 않은 미션 트랙 요청: email={}, track={}", email, trackName);
-            return List.of(); // 빈 리스트 반환하여 에러 방지
-        }
-    }
-
-    // 보유 칭호 목록 조회
-    @Transactional(readOnly = true)
-    public List<MemberTitleResponse> getMyTitles(String email) {
-        Member member = getMemberByEmail(email);
-        return memberTitleRepository.findAllByMember(member).stream()
-                .map(MemberTitleResponse::new)
-                .collect(Collectors.toList());
     }
 
     // --- [공통 로직] 완료 처리, 보상, 초기화 ---
@@ -848,12 +655,6 @@ public class MissionService {
         attendanceProgress.incrementProgress(1);
         checkMissionCompletion(attendanceProgress);
         return attendanceProgress.getMission().getReward();
-    }
-
-    @Transactional(readOnly = true)
-    public List<MissionProgress> getMissionProgressList(String email) {
-        Member member = getMemberByEmail(email);
-        return missionProgressRepository.findByMemberWithMissionAndReward(member);
     }
 
     @Transactional

--- a/src/main/java/grit/stockIt/domain/mission/service/MissionService.java
+++ b/src/main/java/grit/stockIt/domain/mission/service/MissionService.java
@@ -15,20 +15,15 @@ import grit.stockIt.domain.mission.enums.MissionTrack;
 import grit.stockIt.domain.mission.enums.MissionType;
 import grit.stockIt.domain.mission.repository.MissionProgressRepository;
 import grit.stockIt.domain.mission.repository.MissionRepository;
-import grit.stockIt.domain.order.entity.OrderMethod;
-import grit.stockIt.domain.order.event.TradeCompletionEvent;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import grit.stockIt.domain.stock.entity.Stock;
-import grit.stockIt.domain.stock.repository.StockRepository;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -44,168 +39,9 @@ public class MissionService {
     private final MissionProgressRepository missionProgressRepository;
     private final AccountRepository accountRepository;
     private final AccountStockRepository accountStockRepository; // [추가됨] 홀딩 여부 확인용
-    private final StockRepository stockRepository;
-    private final MissionConditionEvaluator missionConditionEvaluator;
-    private final MissionProgressCalculator missionProgressCalculator;
     private final MissionTrackPolicy missionTrackPolicy;
     private final MissionRewardService missionRewardService;
 
-    private static final long JUNK_STOCK_MARKET_CAP_THRESHOLD = 100000000000L;
-    /**
-     * [1] (이벤트 수신) 거래 이벤트 발생 시 미션 진행도 업데이트
-     * - 일반 미션 갱신 로직
-     * - 매도(SELL) 발생 시 '홀딩' 미션 초기화 로직 포함
-     */
-    public void updateMissionProgress(TradeCompletionEvent event) {
-        log.info("수신된 거래 이벤트: MemberId={}, Method={}, Qty={}",
-                event.getMemberId(), event.getOrderMethod(), event.getFilledQuantity());
-
-        // 🛑 [신규 추가] 기본 계좌 검증 로직
-        // 1. 이벤트에 계좌 ID가 없거나, 기본 계좌가 아니면 미션 집계에서 제외
-        if (event.getAccountId() != null) {
-            boolean isDefaultAccount = accountRepository.findById(event.getAccountId())
-                    .map(Account::getIsDefault)
-                    .orElse(false); // 계좌가 없으면 false 취급
-
-            if (!isDefaultAccount) {
-                log.info("보조 계좌 거래 감지: 미션 및 랭킹 집계에서 제외합니다. (AccountId={})", event.getAccountId());
-                return; // 여기서 메서드 종료!
-            }
-        } else {
-            // (선택 사항) AccountId가 null인 옛날 코드 호환성을 위해 경고만 찍고 진행할지, 막을지 결정
-            // 여기서는 안전하게 로그 찍고 진행 (혹은 return으로 막으셔도 됨)
-            log.warn("거래 이벤트에 AccountId가 없습니다. 기본 계좌 여부를 확인할 수 없습니다.");
-        }
-
-        Member member = memberRepository.findById(event.getMemberId())
-                .orElseThrow(() -> new EntityNotFoundException("회원을 찾을 수 없습니다."));
-
-        // 1. 회원의 '진행 중'인 미션 목록 조회
-        List<MissionProgress> progressList = missionProgressRepository
-                .findByMemberAndStatusWithMission(member, MissionStatus.IN_PROGRESS);
-
-        // 2. 진행 중인 미션 순회
-        for (MissionProgress progress : progressList) {
-            Mission mission = progress.getMission();
-            MissionConditionType type = mission.getConditionType();
-
-            // 🚨 [핵심 로직] 매도(SELL) 발생 시 -> '홀딩' 미션은 무조건 0으로 초기화 (존버 실패)
-            if (event.getOrderMethod() == OrderMethod.SELL && type == MissionConditionType.HOLDING_DAYS) {
-                if (progress.getCurrentValue() > 0) {
-                    log.info("매도 발생으로 홀딩 미션 리셋! MissionId={}, 기존값={}",
-                            mission.getId(), progress.getCurrentValue());
-                    progress.setCurrentValue(0); // 0일차로 초기화
-                }
-                continue; // 초기화했으니 다른 검사는 건너뜀
-            }
-
-            // 3. 그 외 조건 매칭 여부 확인 및 업데이트
-            if (missionConditionEvaluator.isMissionConditionMatches(mission, event)) {
-                updateProgressValue(progress, mission, event);
-            }
-        }
-        // 2. [신규] 특수 업적 미션 체크 (달콤한 첫입, 강형욱)
-        checkSpecialAchievement(member, event);
-
-        // [추가] 매도(SELL) 발생 시 실력 점수 반영
-        if (event.getOrderMethod() == OrderMethod.SELL) {
-            updateSkillScore(event);
-        }
-    }
-
-    /**
-     * [수정] 실력 점수 로직 -> "누적 수익금 업데이트"로 변경
-     * - 매도 시 발생한 수익금(손실금)을 있는 그대로 더함
-     * - 점수 변환(제곱근)은 조회 시점에 수행
-     */
-    private void updateSkillScore(TradeCompletionEvent event) {
-        Member member = memberRepository.findById(event.getMemberId()).orElseThrow();
-
-        // 1. 이번 거래의 수익금 계산
-        BigDecimal sellAmount = event.getFilledAmount();
-        BigDecimal buyCost = event.getBuyAveragePrice().multiply(BigDecimal.valueOf(event.getFilledQuantity()));
-        BigDecimal profit = sellAmount.subtract(buyCost);
-
-        int profitInt = profit.intValue(); // 억 단위 이상이 아니라면 int로 충분
-        if (profitInt == 0) return;
-
-        // 2. 트래커(ID 999)에 수익금 누적
-        missionProgressRepository.findByMemberAndMissionTypeWithMission(member, MissionTrack.ACHIEVEMENT, MissionConditionType.SKILL_SCORE)
-                .ifPresent(tracker -> {
-                    int currentTotalProfit = tracker.getCurrentValue();
-                    int newTotalProfit = currentTotalProfit + profitInt;
-
-                    // 순수 수익금 저장 (마이너스 수익이면 전체 수익금이 깎임)
-                    tracker.setCurrentValue(newTotalProfit);
-
-                    log.info("누적 수익금 갱신: Member={}, 이번수익={}원, 총누적={}원",
-                            member.getName(), profitInt, newTotalProfit);
-
-                    // Legend 달성 체크 (현재 총 수익금 기반으로 점수 환산하여 체크)
-                    missionRewardService.checkLegendTier(member, getActivityScore(member) + missionProgressCalculator.calculateScoreFromProfit(newTotalProfit));
-                });
-    }
-
-    /**
-     * [Helper] 현재 활동 점수(Activity Score) 조회
-     * - 트래커 미션(998번)의 현재 값을 가져옴
-     * - 없으면 0점 반환
-     */
-    private int getActivityScore(Member member) {
-        return missionProgressRepository.findByMemberAndMissionTypeWithMission(
-                        member,
-                        MissionTrack.ACHIEVEMENT,
-                        MissionConditionType.ACTIVITY_SCORE
-                )
-                .map(MissionProgress::getCurrentValue)
-                .orElse(0);
-    }
-    /**
-     * [신규] 특수 조건 업적 처리
-     * - 달콤한 첫입 (FIRST_PROFIT)
-     * - 강형욱 (JUNK_STOCK_JACKPOT)
-     */
-    private void checkSpecialAchievement(Member member, TradeCompletionEvent event) {
-        // 매도가 아니거나 수익이 없으면 패스
-        if (event.getOrderMethod() != OrderMethod.SELL) return;
-
-        // 수익 여부 판단 (매도가 > 평단가)
-        boolean isProfit = event.getFilledPrice().compareTo(event.getBuyAveragePrice()) > 0;
-        if (!isProfit) return;
-
-        // A. 달콤한 첫입 (첫 수익 실현)
-        handleOneTimeAchievement(member, MissionConditionType.FIRST_PROFIT, 1);
-
-        // B. 강형욱 (잡주로 100% 이상 수익)
-        // 종목 정보 조회
-        Stock stock = stockRepository.findById(event.getStockCode()).orElse(null);
-
-/*        // 시가총액 1,000억 미만이고, 수익률이 100% 이상인 경우
-        if (stock != null && stock.getMarketCap() < JUNK_STOCK_MARKET_CAP_THRESHOLD) {
-            // 수익률 계산: (매도가 - 평단가) / 평단가
-            BigDecimal profitRate = event.getFilledPrice().subtract(event.getBuyAveragePrice())
-                    .divide(event.getBuyAveragePrice(), 2, java.math.RoundingMode.HALF_UP);
-
-            // 1.0 이상 (100%)
-            if (profitRate.compareTo(BigDecimal.ONE) >= 0) {
-                log.info("잡주 대박 터짐! Member={}, Stock={}, Rate={}", member.getName(), stock.getName(), profitRate);
-                handleOneTimeAchievement(member, MissionConditionType.JUNK_STOCK_JACKPOT, 1);
-            }
-        }*/
-    }
-
-    /**
-     * 1회성 업적 달성 처리 헬퍼 (이미 완료되었으면 무시)
-     */
-    private void handleOneTimeAchievement(Member member, MissionConditionType type, int value) {
-        missionProgressRepository.findByMemberAndMissionTypeWithMission(member, MissionTrack.ACHIEVEMENT, type)
-                .ifPresent(progress -> {
-                    if (!progress.isCompleted()) {
-                        progress.setCurrentValue(value);
-                        missionRewardService.checkMissionCompletion(progress);
-                    }
-                });
-    }
     /**
      * [신규] 스케줄러 호출용: 매일 자정에 보유 주식이 있으면 홀딩 일수 +1
      */
@@ -225,42 +61,6 @@ public class MissionService {
                 log.info("홀딩 미션 +1일 증가: MemberId={}, MissionId={}, NewValue={}",
                         member.getMemberId(), progress.getMission().getId(), progress.getCurrentValue());
                 missionRewardService.checkMissionCompletion(progress);
-            }
-        }
-    }
-
-    // [수정] 진행도 업데이트 로직 개선
-    private void updateProgressValue(MissionProgress progress, Mission mission, TradeCompletionEvent event) {
-        MissionConditionType type = mission.getConditionType();
-        int goal = mission.getGoalValue();
-
-        // A. 누적형 (카운트 증가) - 기존과 동일
-        if (missionConditionEvaluator.isCumulativeType(type)) {
-            int valueToIncrease = missionProgressCalculator.calculateIncreaseValue(type, event);
-            if (valueToIncrease > 0) {
-                progress.incrementProgress(valueToIncrease);
-                log.info("미션(누적) 갱신: MissionId={}, Added={}, Current={}",
-                        mission.getId(), valueToIncrease, progress.getCurrentValue());
-                missionRewardService.checkMissionCompletion(progress);
-            }
-        }
-        // B. 달성형 (임계값 돌파 / 최고 기록 갱신) - [수정됨]
-        else if (missionConditionEvaluator.isThresholdType(type)) {
-            int eventValue = missionProgressCalculator.calculateThresholdValue(type, event);
-
-            // 현재 기록보다 더 높은 기록이 나오면 갱신 (Best Record)
-            if (eventValue > progress.getCurrentValue()) {
-                // 목표치보다 크면 목표치로 고정 (100% 달성 표시를 위해)
-                int newValue = Math.min(eventValue, goal);
-                progress.setCurrentValue(newValue);
-
-                log.info("미션(달성형) 기록 갱신: MissionId={}, NewBest={}, Goal={}",
-                        mission.getId(), newValue, goal);
-
-                // 목표 달성 여부 체크
-                if (eventValue >= goal) {
-                    missionRewardService.checkMissionCompletion(progress);
-                }
             }
         }
     }
@@ -340,47 +140,6 @@ public class MissionService {
 
         log.info("파산 승인 및 티어 초기화 완료: Member={}", member.getName());
         return bankruptcyProgress.getMission().getReward();
-    }
-
-    /**
-     * [신규] 랭킹 Top 10 달성 처리 (스케줄러 호출용)
-     * - RankingService에서 1분마다 Top 10 유저 ID 리스트를 넘겨줌
-     */
-    public void processRankerAchievement(List<Long> topRankerIds) {
-        if (topRankerIds.isEmpty()) return;
-
-        // 1. 'RANKING_TOP_10' 조건의 업적 미션 조회 (미션 ID: 909 '랭커')
-        Mission rankerMission = missionRepository.findAllByTrackAndConditionType(MissionTrack.ACHIEVEMENT, MissionConditionType.RANKING_TOP_10)
-                .stream().findFirst()
-                .orElse(null);
-
-        if (rankerMission == null) return;
-
-        // 2. Top 10 유저들을 순회하며 미션 달성 처리
-        for (Long memberId : topRankerIds) {
-            Member member = memberRepository.findById(memberId).orElse(null);
-            if (member == null) continue;
-
-            // 3. 미션 진행도 조회 또는 생성
-            MissionProgress progress = missionProgressRepository
-                    .findByMemberAndMission(member, rankerMission)
-                    .orElseGet(() -> {
-                        MissionProgress newProgress = MissionProgress.builder()
-                                .member(member)
-                                .mission(rankerMission)
-                                .status(MissionStatus.IN_PROGRESS)
-                                .build();
-                        member.addMissionProgress(newProgress);
-                        return newProgress;
-                    });
-
-            // 4. 이미 완료한 사람은 패스 (칭호 중복 지급 방지)
-            if (!progress.isCompleted()) {
-                log.info("랭커 등극! 칭호 지급: MemberId={}", memberId);
-                progress.setCurrentValue(10); // 목표치(10) 달성 처리
-                missionRewardService.checkMissionCompletion(progress); // 보상(칭호) 지급 및 완료 처리
-            }
-        }
     }
 
     @Transactional

--- a/src/main/java/grit/stockIt/domain/mission/service/MissionService.java
+++ b/src/main/java/grit/stockIt/domain/mission/service/MissionService.java
@@ -43,51 +43,6 @@ public class MissionService {
     private final MissionRewardService missionRewardService;
 
     /**
-     * [신규] 스케줄러 호출용: 매일 자정에 보유 주식이 있으면 홀딩 일수 +1
-     */
-    public void processDailyHoldingUpdate() {
-        // 1. 'HOLDING_DAYS' 조건이면서 '진행 중'인 미션들만 조회
-        List<MissionProgress> holdingProgressList = missionProgressRepository
-                .findAllByMission_ConditionTypeAndStatus(MissionConditionType.HOLDING_DAYS, MissionStatus.IN_PROGRESS);
-
-        for (MissionProgress progress : holdingProgressList) {
-            Member member = progress.getMember();
-
-            // 2. 회원이 주식을 하나라도 가지고 있는지 확인 (수량 > 0)
-            boolean hasStock = accountStockRepository.existsByAccount_MemberAndQuantityGreaterThan(member, 0);
-
-            if (hasStock) {
-                progress.incrementProgress(1);
-                log.info("홀딩 미션 +1일 증가: MemberId={}, MissionId={}, NewValue={}",
-                        member.getMemberId(), progress.getMission().getId(), progress.getCurrentValue());
-                missionRewardService.checkMissionCompletion(progress);
-            }
-        }
-    }
-
-    // ... 기존 메서드들 ...
-
-    /**
-     * [리팩토링] 연속 출석 초기화 로직
-     * - 타입 안전성을 위해 Enum 상수를 직접 인자로 전달합니다.
-     */
-    @Transactional
-    public void checkAndResetAttendanceStreaks() {
-        log.info("연속 출석 끊김 여부 확인 및 초기화 시작 (Bulk Update)...");
-
-        // 변경된 메서드 시그니처에 맞춰 Enum 값 전달
-        int updatedCount = missionProgressRepository.bulkResetLoginStreakForAbsentees(
-                MissionTrack.ACHIEVEMENT,           // :streakTrack (업적 트랙)
-                MissionConditionType.LOGIN_STREAK,  // :streakCondition (연속 출석 체크용)
-                MissionTrack.DAILY,                 // :dailyTrack (일일 미션 트랙)
-                MissionConditionType.LOGIN_COUNT,   // :dailyCondition (일일 출석 여부 확인용)
-                MissionStatus.COMPLETED             // :completedStatus (완료 상태 기준)
-        );
-
-        log.info("총 {}건의 연속 출석 기록이 일괄 초기화되었습니다.", updatedCount);
-    }
-
-    /**
      * [신규] 인생 2회차 (파산 신청) API 로직
      * - 조건: (보유 현금 + 보유 주식의 원금 총액) < 50,000원
      */
@@ -140,26 +95,6 @@ public class MissionService {
 
         log.info("파산 승인 및 티어 초기화 완료: Member={}", member.getName());
         return bankruptcyProgress.getMission().getReward();
-    }
-
-    @Transactional
-    public void resetDailyMissions() {
-        log.info("일일 미션 전체 초기화 시작...");
-        List<MissionProgress> dailyProgressList = missionProgressRepository.findAllByMission_Track(MissionTrack.DAILY);
-        for (MissionProgress progress : dailyProgressList) {
-            progress.reset();
-        }
-
-        // 2. [신규] Track = ACHIEVEMENT 이지만 'DAILY_TRADE_COUNT' 타입인 미션(카이팅 장인) 초기화
-        // (완료하지 못한 경우에만 리셋해야 함)
-        List<MissionProgress> kitingMissions = missionProgressRepository
-                .findAllByMission_ConditionTypeAndStatus(MissionConditionType.DAILY_TRADE_COUNT, MissionStatus.IN_PROGRESS);
-
-        for (MissionProgress mp : kitingMissions) {
-            // 업적이라 트랙은 ACHIEVEMENT지만 성격은 Daily이므로 매일 리셋
-            mp.setCurrentValue(0);
-        }
-        log.info("일일 미션 총 {}건 초기화 완료.", dailyProgressList.size());
     }
 
     @Transactional

--- a/src/main/java/grit/stockIt/domain/mission/service/MissionTierPolicy.java
+++ b/src/main/java/grit/stockIt/domain/mission/service/MissionTierPolicy.java
@@ -1,0 +1,17 @@
+package grit.stockIt.domain.mission.service;
+
+/**
+ * 미션 티어 정책 상수의 단일 출처(SSOT).
+ *
+ * LEGEND 등급 기준 점수는 보상 지급(MissionRewardService.checkLegendTier)과
+ * 티어 조회(MissionQueryService.getTierInfo) 양쪽에서 참조되는데, 분해 후 두 파일로
+ * 값이 갈라져 한쪽만 바꾸면 조용히 어긋날 수 있다. 이를 방지하기 위해 여기 한 곳에 둔다.
+ */
+public final class MissionTierPolicy {
+
+    /** LEGEND 등급 도달 기준 총점 */
+    public static final int LEGEND_THRESHOLD_SCORE = 3600;
+
+    private MissionTierPolicy() {
+    }
+}

--- a/src/main/java/grit/stockIt/domain/mission/service/MissionTrackPolicy.java
+++ b/src/main/java/grit/stockIt/domain/mission/service/MissionTrackPolicy.java
@@ -1,0 +1,16 @@
+package grit.stockIt.domain.mission.service;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * [B-1 추출] 트랙 구조 정책 순수 로직 (data.sql 시드 ID 캡슐화).
+ * Spring 컨텍스트 없이 new로 직접 생성하여 단위 테스트할 수 있다.
+ */
+@Component
+public class MissionTrackPolicy {
+
+    public boolean isFirstMissionInTrack(long missionId) {
+        // data.sql 기준 첫 미션 ID (201: 단타, 301: 스윙, 401: 장기)
+        return missionId == 201 || missionId == 301 || missionId == 401;
+    }
+}

--- a/src/main/java/grit/stockIt/domain/ranking/service/RankingService.java
+++ b/src/main/java/grit/stockIt/domain/ranking/service/RankingService.java
@@ -7,7 +7,7 @@ import grit.stockIt.domain.account.repository.AccountStockRepository;
 import grit.stockIt.domain.contest.entity.Contest;
 import grit.stockIt.domain.contest.repository.ContestRepository;
 import grit.stockIt.domain.matching.repository.RedisMarketDataRepository;
-import grit.stockIt.domain.mission.service.MissionProgressService;
+import grit.stockIt.domain.mission.event.RankerAchievedEvent;
 import grit.stockIt.domain.mission.service.MissionQueryService;
 import grit.stockIt.domain.mission.dto.UserTierStatusResponse;
 import grit.stockIt.domain.ranking.dto.MyRankResponse;
@@ -17,6 +17,7 @@ import grit.stockIt.domain.stock.service.StockDetailService;
 import com.google.common.util.concurrent.RateLimiter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.core.env.Environment;
@@ -46,7 +47,7 @@ public class RankingService {
     private final AccountRepository accountRepository;
     private final AccountStockRepository accountStockRepository;
     private final ContestRepository contestRepository;
-    private final MissionProgressService missionProgressService;
+    private final ApplicationEventPublisher eventPublisher;
     private final MissionQueryService missionQueryService;
     private final RedisMarketDataRepository redisMarketDataRepository;
     private final StockDetailService stockDetailService;
@@ -93,9 +94,9 @@ public class RankingService {
                         .map(RankingItemResponse::getMemberId)       // MemberId 추출
                         .collect(Collectors.toList());
 
-                // MissionProgressService로 Top 10 명단 전달 (미션 달성 처리)
+                // 랭커 달성 이벤트 발행 (동기 리스너가 미션 달성 처리 — 예외는 아래 catch에 흡수)
                 if (!top10MemberIds.isEmpty()) {
-                    missionProgressService.processRankerAchievement(top10MemberIds);
+                    eventPublisher.publishEvent(new RankerAchievedEvent(top10MemberIds));
                 }
             }
             // 2. 진행 중인 대회 랭킹 갱신

--- a/src/main/java/grit/stockIt/domain/ranking/service/RankingService.java
+++ b/src/main/java/grit/stockIt/domain/ranking/service/RankingService.java
@@ -7,7 +7,7 @@ import grit.stockIt.domain.account.repository.AccountStockRepository;
 import grit.stockIt.domain.contest.entity.Contest;
 import grit.stockIt.domain.contest.repository.ContestRepository;
 import grit.stockIt.domain.matching.repository.RedisMarketDataRepository;
-import grit.stockIt.domain.mission.service.MissionService;
+import grit.stockIt.domain.mission.service.MissionProgressService;
 import grit.stockIt.domain.mission.service.MissionQueryService;
 import grit.stockIt.domain.mission.dto.UserTierStatusResponse;
 import grit.stockIt.domain.ranking.dto.MyRankResponse;
@@ -46,7 +46,7 @@ public class RankingService {
     private final AccountRepository accountRepository;
     private final AccountStockRepository accountStockRepository;
     private final ContestRepository contestRepository;
-    private final MissionService missionService;
+    private final MissionProgressService missionProgressService;
     private final MissionQueryService missionQueryService;
     private final RedisMarketDataRepository redisMarketDataRepository;
     private final StockDetailService stockDetailService;
@@ -93,9 +93,9 @@ public class RankingService {
                         .map(RankingItemResponse::getMemberId)       // MemberId 추출
                         .collect(Collectors.toList());
 
-                // MissionService로 Top 10 명단 전달 (미션 달성 처리)
+                // MissionProgressService로 Top 10 명단 전달 (미션 달성 처리)
                 if (!top10MemberIds.isEmpty()) {
-                    missionService.processRankerAchievement(top10MemberIds);
+                    missionProgressService.processRankerAchievement(top10MemberIds);
                 }
             }
             // 2. 진행 중인 대회 랭킹 갱신

--- a/src/main/java/grit/stockIt/domain/ranking/service/RankingService.java
+++ b/src/main/java/grit/stockIt/domain/ranking/service/RankingService.java
@@ -8,6 +8,7 @@ import grit.stockIt.domain.contest.entity.Contest;
 import grit.stockIt.domain.contest.repository.ContestRepository;
 import grit.stockIt.domain.matching.repository.RedisMarketDataRepository;
 import grit.stockIt.domain.mission.service.MissionService;
+import grit.stockIt.domain.mission.service.MissionQueryService;
 import grit.stockIt.domain.mission.dto.UserTierStatusResponse;
 import grit.stockIt.domain.ranking.dto.MyRankResponse;
 import grit.stockIt.domain.ranking.dto.RankingItemResponse;
@@ -46,6 +47,7 @@ public class RankingService {
     private final AccountStockRepository accountStockRepository;
     private final ContestRepository contestRepository;
     private final MissionService missionService;
+    private final MissionQueryService missionQueryService;
     private final RedisMarketDataRepository redisMarketDataRepository;
     private final StockDetailService stockDetailService;
     private final Environment environment;
@@ -278,7 +280,7 @@ public class RankingService {
      */
     private String getTierForMember(grit.stockIt.domain.member.entity.Member member) {
         try {
-            UserTierStatusResponse tierInfo = missionService.getTierInfo(member.getEmail());
+            UserTierStatusResponse tierInfo = missionQueryService.getTierInfo(member.getEmail());
             return tierInfo.getCurrentTier();
         } catch (Exception e) {
             log.warn("티어 조회 실패 (memberId: {}): {}", member.getMemberId(), e.getMessage());

--- a/src/test/java/grit/stockIt/domain/matching/service/LimitOrderMatchingServiceConcurrencyTest.java
+++ b/src/test/java/grit/stockIt/domain/matching/service/LimitOrderMatchingServiceConcurrencyTest.java
@@ -18,27 +18,18 @@ import grit.stockIt.domain.order.entity.OrderStatus;
 import grit.stockIt.domain.order.repository.OrderHoldRepository;
 import grit.stockIt.domain.order.repository.OrderRepository;
 import grit.stockIt.domain.execution.repository.ExecutionRepository;
+import grit.stockIt.global.support.IntegrationTestSupport;
 import grit.stockIt.domain.stock.entity.Stock;
 import grit.stockIt.domain.stock.repository.StockRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -50,37 +41,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest
-@ActiveProfiles("test")
-@Testcontainers
-@TestPropertySource(properties = "spring.task.scheduling.enabled=false")
+// 컨테이너·프로파일 설정은 IntegrationTestSupport 싱글턴을 상속 — 자체 @Container 선언은
+// reuse 활성 환경에서 같은 해시의 공유 컨테이너를 클래스 종료 시 stop시켜, 캐시된 다른
+// 테스트 컨텍스트를 전멸시키는 원인이었다(동일 설정이라 동작은 그대로).
 @DisplayName("LimitOrderMatchingService 동시성 제어 테스트 (통합 테스트)")
-class LimitOrderMatchingServiceConcurrencyTest {
-
-    @Container
-    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>(DockerImageName.parse("postgres:15"))
-            .withDatabaseName("test_database")
-            .withUsername("test_user")
-            .withPassword("test_password")
-            .withReuse(true);  // 컨테이너 재사용으로 성능 향상
-
-    @Container
-    static GenericContainer<?> redis = new GenericContainer<>(DockerImageName.parse("redis:7"))
-            .withExposedPorts(6379)
-            .withReuse(true);  // 컨테이너 재사용으로 성능 향상
-
-    @DynamicPropertySource
-    static void configureProperties(DynamicPropertyRegistry registry) {
-        // PostgreSQL 설정
-        registry.add("spring.datasource.url", postgres::getJdbcUrl);
-        registry.add("spring.datasource.username", postgres::getUsername);
-        registry.add("spring.datasource.password", postgres::getPassword);
-        registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
-        
-        // Redis 설정
-        registry.add("spring.data.redis.host", redis::getHost);
-        registry.add("spring.data.redis.port", redis::getFirstMappedPort);
-    }
+class LimitOrderMatchingServiceConcurrencyTest extends IntegrationTestSupport {
 
     @Autowired
     private LimitOrderMatchingService limitOrderMatchingService;

--- a/src/test/java/grit/stockIt/domain/mission/service/MemberSignupMissionFlowIntegrationTest.java
+++ b/src/test/java/grit/stockIt/domain/mission/service/MemberSignupMissionFlowIntegrationTest.java
@@ -1,0 +1,167 @@
+package grit.stockIt.domain.mission.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+
+import grit.stockIt.domain.account.entity.Account;
+import grit.stockIt.domain.account.repository.AccountRepository;
+import grit.stockIt.domain.auth.service.KakaoAuthService;
+import grit.stockIt.domain.member.dto.MemberSignupRequest;
+import grit.stockIt.domain.member.entity.Member;
+import grit.stockIt.domain.member.repository.MemberRepository;
+import grit.stockIt.domain.member.service.LocalMemberService;
+import grit.stockIt.domain.mission.entity.Mission;
+import grit.stockIt.domain.mission.entity.MissionProgress;
+import grit.stockIt.domain.mission.enums.MissionStatus;
+import grit.stockIt.domain.mission.repository.MissionProgressRepository;
+import grit.stockIt.domain.mission.repository.MissionRepository;
+import grit.stockIt.global.jwt.JwtToken;
+import grit.stockIt.global.support.IntegrationTestSupport;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.test.context.jdbc.Sql;
+
+/**
+ * [특성화 테스트 / A-5] 회원가입 → 계좌 생성 → 미션 초기화 도메인 간 커맨드 경로.
+ *
+ * 리팩토링(커맨드 → 이벤트 전환) 전후로 무수정 재사용하기 위해
+ * 관찰 가능한 결과(DB 상태)만 단언하고, 호출/주입 메커니즘은 검증하지 않는다.
+ *
+ * 시드: data.sql (idempotent upsert) — 트랙 첫 미션 201/301/401, 활동 점수 트래커 998.
+ * 기본 대회(Contest)는 DefaultContestInitializer(ApplicationRunner)가 컨텍스트 기동 시 생성한다.
+ */
+@Sql(scripts = "/data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+class MemberSignupMissionFlowIntegrationTest extends IntegrationTestSupport {
+
+    @Autowired
+    private LocalMemberService localMemberService;
+
+    @Autowired
+    private KakaoAuthService kakaoAuthService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    @Autowired
+    private MissionRepository missionRepository;
+
+    @Autowired
+    private MissionProgressRepository missionProgressRepository;
+
+    /**
+     * 롤백 전파 시나리오에서만 강제 예외를 스터빙한다.
+     * 스터빙하지 않은 테스트에서는 실제 빈으로 위임되므로 성공 경로 동작에 영향이 없다.
+     */
+    @MockitoSpyBean
+    private MissionService missionService;
+
+    private static String uniqueEmail(String prefix) {
+        // 컨테이너 재사용(withReuse) + 실커밋 테스트이므로 이메일 충돌 방지를 위해 매번 유일한 값 사용
+        // 주의: 로컬 가입은 이메일 로컬파트를 name으로 쓰는데 member.name 컬럼이 varchar(20)이라 짧게 유지
+        return prefix + UUID.randomUUID().toString().substring(0, 13).replace("-", "") + "@test.com";
+    }
+
+    @Test
+    @DisplayName("로컬 가입 성공 시 member/account/mission_progress가 한 번에 생성된다")
+    void 로컬_가입_성공시_member_account_missionProgress가_함께_생성된다() {
+        // given
+        String email = uniqueEmail("loc");
+        MemberSignupRequest request = new MemberSignupRequest(email, "password123!");
+
+        // when
+        localMemberService.signup(request);
+
+        // then: member 생성
+        Optional<Member> found = memberRepository.findByEmail(email);
+        assertThat(found).isPresent();
+        Member member = found.get();
+
+        // then: 디폴트 계좌 생성 (기본 대회 기준, isDefault=true)
+        Optional<Account> defaultAccount = accountRepository.findByMemberAndIsDefaultTrue(member);
+        assertThat(defaultAccount).isPresent();
+
+        // then: 트랙 첫 미션(201/301/401)만 IN_PROGRESS, 진행도 0
+        assertTrackFirstMissionActive(member, 201L);
+        assertTrackFirstMissionActive(member, 301L);
+        assertTrackFirstMissionActive(member, 401L);
+
+        // then: 활동 점수 트래커(998)는 초기값 1200 (Silver 1티어 시작)
+        MissionProgress activityScore = progressOf(member, 998L);
+        // 특성화: 현재 동작 — ACTIVITY_SCORE 트래커만 0이 아닌 1200으로 하드코딩 시작
+        assertThat(activityScore.getCurrentValue()).isEqualTo(1200);
+        assertThat(activityScore.getStatus()).isEqualTo(MissionStatus.IN_PROGRESS);
+    }
+
+    @Test
+    @DisplayName("카카오 completeSignup 경로도 member/account/mission_progress를 함께 생성한다")
+    void 카카오_completeSignup_경로도_member_account_missionProgress를_함께_생성한다() {
+        // completeSignup은 카카오 OAuth 외부 호출 없이 DB 저장 + JWT 발급만 수행하므로 직접 호출 가능(실측 확인)
+        // given
+        String email = uniqueEmail("kko");
+
+        // when
+        JwtToken token = kakaoAuthService.completeSignup(email, "카카오테스터", null);
+
+        // then: JWT 발급
+        assertThat(token.getAccessToken()).isNotBlank();
+
+        // then: member/account/mission_progress 동시 존재
+        Optional<Member> found = memberRepository.findByEmail(email);
+        assertThat(found).isPresent();
+        Member member = found.get();
+
+        assertThat(accountRepository.findByMemberAndIsDefaultTrue(member)).isPresent();
+
+        assertTrackFirstMissionActive(member, 201L);
+        assertTrackFirstMissionActive(member, 301L);
+        assertTrackFirstMissionActive(member, 401L);
+
+        MissionProgress activityScore = progressOf(member, 998L);
+        assertThat(activityScore.getCurrentValue()).isEqualTo(1200);
+        assertThat(activityScore.getStatus()).isEqualTo(MissionStatus.IN_PROGRESS);
+    }
+
+    @Test
+    @DisplayName("미션 초기화 실패 시 signup 트랜잭션 전체가 롤백된다 (member/account 행 부재)")
+    void 미션_초기화_실패시_signup_전체가_롤백된다() {
+        // given
+        String email = uniqueEmail("rbk");
+        MemberSignupRequest request = new MemberSignupRequest(email, "password123!");
+        long accountCountBefore = accountRepository.count();
+
+        doThrow(new RuntimeException("미션 초기화 강제 실패"))
+                .when(missionService).initializeMissionsForNewMember(any(Member.class));
+
+        // when & then: 예외가 signup 호출자까지 전파된다
+        // 특성화: 현재 동작 — 미션 초기화 실패가 가입 전체를 실패시킴 (커맨드 방식 동기 결합)
+        assertThatThrownBy(() -> localMemberService.signup(request))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("미션 초기화 강제 실패");
+
+        // then: member/account 행 부재 (전체 롤백)
+        assertThat(memberRepository.findByEmail(email)).isEmpty();
+        assertThat(accountRepository.count()).isEqualTo(accountCountBefore);
+    }
+
+    private void assertTrackFirstMissionActive(Member member, long missionId) {
+        MissionProgress progress = progressOf(member, missionId);
+        assertThat(progress.getStatus()).isEqualTo(MissionStatus.IN_PROGRESS);
+        assertThat(progress.getCurrentValue()).isZero();
+    }
+
+    private MissionProgress progressOf(Member member, long missionId) {
+        Mission mission = missionRepository.findById(missionId)
+                .orElseThrow(() -> new IllegalStateException("data.sql 시드 미션 없음: " + missionId));
+        return missionProgressRepository.findByMemberAndMission(member, mission)
+                .orElseThrow(() -> new IllegalStateException("mission_progress 없음: missionId=" + missionId));
+    }
+}

--- a/src/test/java/grit/stockIt/domain/mission/service/MissionConditionEvaluatorTest.java
+++ b/src/test/java/grit/stockIt/domain/mission/service/MissionConditionEvaluatorTest.java
@@ -1,0 +1,93 @@
+package grit.stockIt.domain.mission.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import grit.stockIt.domain.mission.entity.Mission;
+import grit.stockIt.domain.mission.enums.MissionConditionType;
+import grit.stockIt.domain.order.entity.OrderMethod;
+import grit.stockIt.domain.order.event.TradeCompletionEvent;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+/**
+ * [B-1 단위 특성화] MissionConditionEvaluator — Phase A 통합 경유 특성화를 직접 호출로 승격.
+ * 전 조건 분기표(매수 전용 / 매도 전용 / 공통 / 비거래)를 그대로 고정한다.
+ */
+@DisplayName("MissionConditionEvaluator 단위 특성화 테스트")
+class MissionConditionEvaluatorTest {
+
+    private final MissionConditionEvaluator evaluator = new MissionConditionEvaluator();
+
+    private static Mission missionOf(MissionConditionType type) {
+        return Mission.builder().conditionType(type).build();
+    }
+
+    private static TradeCompletionEvent eventOf(OrderMethod method) {
+        return new TradeCompletionEvent(1L, 1L, "005930", method, 1, new BigDecimal("10000"));
+    }
+
+    // --- isMissionConditionMatches: 조건 분기표 ---
+
+    @ParameterizedTest
+    @EnumSource(value = MissionConditionType.class, names = {"BUY_COUNT", "BUY_AMOUNT"})
+    void 매수전용_조건은_BUY에만_매칭된다(MissionConditionType type) {
+        assertThat(evaluator.isMissionConditionMatches(missionOf(type), eventOf(OrderMethod.BUY))).isTrue();
+        assertThat(evaluator.isMissionConditionMatches(missionOf(type), eventOf(OrderMethod.SELL))).isFalse();
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = MissionConditionType.class,
+            names = {"SELL_COUNT", "SELL_AMOUNT", "PROFIT_RATE", "DAILY_PROFIT_COUNT", "PROFIT_AMOUNT"})
+    void 매도전용_조건은_SELL에만_매칭된다(MissionConditionType type) {
+        assertThat(evaluator.isMissionConditionMatches(missionOf(type), eventOf(OrderMethod.SELL))).isTrue();
+        assertThat(evaluator.isMissionConditionMatches(missionOf(type), eventOf(OrderMethod.BUY))).isFalse();
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = MissionConditionType.class,
+            names = {"TRADE_COUNT", "TOTAL_TRADE_AMOUNT", "DAILY_TRADE_COUNT"})
+    void 공통_조건은_매수와_매도_모두에_매칭된다(MissionConditionType type) {
+        assertThat(evaluator.isMissionConditionMatches(missionOf(type), eventOf(OrderMethod.BUY))).isTrue();
+        assertThat(evaluator.isMissionConditionMatches(missionOf(type), eventOf(OrderMethod.SELL))).isTrue();
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = MissionConditionType.class, mode = EnumSource.Mode.EXCLUDE,
+            names = {"BUY_COUNT", "BUY_AMOUNT",
+                    "SELL_COUNT", "SELL_AMOUNT", "PROFIT_RATE", "DAILY_PROFIT_COUNT", "PROFIT_AMOUNT",
+                    "TRADE_COUNT", "TOTAL_TRADE_AMOUNT", "DAILY_TRADE_COUNT"})
+    void 비거래_조건은_어떤_주문에도_매칭되지_않는다(MissionConditionType type) {
+        assertThat(evaluator.isMissionConditionMatches(missionOf(type), eventOf(OrderMethod.BUY))).isFalse();
+        assertThat(evaluator.isMissionConditionMatches(missionOf(type), eventOf(OrderMethod.SELL))).isFalse();
+    }
+
+    // --- isCumulativeType / isThresholdType: 유형 분기표 ---
+
+    @ParameterizedTest
+    @EnumSource(value = MissionConditionType.class,
+            names = {"TRADE_COUNT", "BUY_COUNT", "SELL_COUNT", "BUY_AMOUNT", "SELL_AMOUNT",
+                    "TOTAL_TRADE_AMOUNT", "DAILY_PROFIT_COUNT", "DAILY_TRADE_COUNT", "PROFIT_RATE"})
+    void 누적형_조건_9종만_isCumulativeType이_참이다(MissionConditionType type) {
+        assertThat(evaluator.isCumulativeType(type)).isTrue();
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = MissionConditionType.class, mode = EnumSource.Mode.EXCLUDE,
+            names = {"TRADE_COUNT", "BUY_COUNT", "SELL_COUNT", "BUY_AMOUNT", "SELL_AMOUNT",
+                    "TOTAL_TRADE_AMOUNT", "DAILY_PROFIT_COUNT", "DAILY_TRADE_COUNT", "PROFIT_RATE"})
+    void 누적형이_아닌_조건은_isCumulativeType이_거짓이다(MissionConditionType type) {
+        assertThat(evaluator.isCumulativeType(type)).isFalse();
+    }
+
+    @Test
+    void 달성형은_PROFIT_AMOUNT_하나뿐이다() {
+        for (MissionConditionType type : MissionConditionType.values()) {
+            assertThat(evaluator.isThresholdType(type))
+                    .as("type %s", type)
+                    .isEqualTo(type == MissionConditionType.PROFIT_AMOUNT);
+        }
+    }
+}

--- a/src/test/java/grit/stockIt/domain/mission/service/MissionProgressCalculatorTest.java
+++ b/src/test/java/grit/stockIt/domain/mission/service/MissionProgressCalculatorTest.java
@@ -1,0 +1,151 @@
+package grit.stockIt.domain.mission.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import grit.stockIt.domain.mission.enums.MissionConditionType;
+import grit.stockIt.domain.order.entity.OrderMethod;
+import grit.stockIt.domain.order.event.TradeCompletionEvent;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+/**
+ * [B-1 단위 특성화] MissionProgressCalculator — Phase A 통합 경유 특성화를 직접 호출로 승격.
+ * 반올림(HALF_UP)·SELL 전제·sqrt(profit/10)·0 이하 -> 0 등 관찰된 현재 동작을 그대로 고정한다.
+ */
+@DisplayName("MissionProgressCalculator 단위 특성화 테스트")
+class MissionProgressCalculatorTest {
+
+    private final MissionProgressCalculator calculator = new MissionProgressCalculator();
+
+    private static TradeCompletionEvent buyEvent(int quantity, String price) {
+        return new TradeCompletionEvent(1L, 1L, "005930", OrderMethod.BUY, quantity, new BigDecimal(price));
+    }
+
+    private static TradeCompletionEvent sellEvent(int quantity, String sellPrice, String buyAveragePrice) {
+        return new TradeCompletionEvent(1L, 1L, "005930", OrderMethod.SELL, quantity, new BigDecimal(sellPrice),
+                null, null, 0, new BigDecimal(buyAveragePrice));
+    }
+
+    // --- calculateIncreaseValue: 누적형 유형별 분기표 ---
+
+    @ParameterizedTest
+    @EnumSource(value = MissionConditionType.class,
+            names = {"TRADE_COUNT", "BUY_COUNT", "SELL_COUNT", "DAILY_TRADE_COUNT"})
+    void 횟수형은_항상_1씩_증가한다(MissionConditionType type) {
+        assertThat(calculator.calculateIncreaseValue(type, buyEvent(3, "10000"))).isEqualTo(1);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = MissionConditionType.class,
+            names = {"BUY_AMOUNT", "SELL_AMOUNT", "TOTAL_TRADE_AMOUNT"})
+    void 금액형은_체결금액_정수부만큼_증가한다(MissionConditionType type) {
+        // 체결금액 = 10,000 x 3 = 30,000
+        assertThat(calculator.calculateIncreaseValue(type, buyEvent(3, "10000"))).isEqualTo(30000);
+    }
+
+    @Test
+    void 일일익절횟수는_SELL이면서_수익일_때만_1이다() {
+        // SELL + 익절 (12,000 > 10,000)
+        assertThat(calculator.calculateIncreaseValue(
+                MissionConditionType.DAILY_PROFIT_COUNT, sellEvent(1, "12000", "10000"))).isEqualTo(1);
+        // SELL + 손절
+        assertThat(calculator.calculateIncreaseValue(
+                MissionConditionType.DAILY_PROFIT_COUNT, sellEvent(1, "9000", "10000"))).isZero();
+        // SELL + 본전 (동가)
+        assertThat(calculator.calculateIncreaseValue(
+                MissionConditionType.DAILY_PROFIT_COUNT, sellEvent(1, "10000", "10000"))).isZero();
+        // BUY (평단가 기본값 0보다 체결가가 커도 매도가 아니므로 0)
+        assertThat(calculator.calculateIncreaseValue(
+                MissionConditionType.DAILY_PROFIT_COUNT, buyEvent(1, "10000"))).isZero();
+    }
+
+    @Test
+    void 수익률_누적은_SELL_전제이고_HALF_UP_반올림된_정수_수익률이다() {
+        // 특성화: BUY면 0
+        assertThat(calculator.calculateIncreaseValue(
+                MissionConditionType.PROFIT_RATE, buyEvent(1, "10000"))).isZero();
+        // 5.5% 수익 -> 6 (HALF_UP)
+        assertThat(calculator.calculateIncreaseValue(
+                MissionConditionType.PROFIT_RATE, sellEvent(1, "10550", "10000"))).isEqualTo(6);
+        // 4.4% 수익 -> 4
+        assertThat(calculator.calculateIncreaseValue(
+                MissionConditionType.PROFIT_RATE, sellEvent(1, "10440", "10000"))).isEqualTo(4);
+        // 특성화: -10% 손실 -> -10 (진행도 깎임, 현재 동작 그대로)
+        assertThat(calculator.calculateIncreaseValue(
+                MissionConditionType.PROFIT_RATE, sellEvent(1, "9000", "10000"))).isEqualTo(-10);
+        // 특성화: 평단가 0이면 계산 불가 -> 0
+        assertThat(calculator.calculateIncreaseValue(
+                MissionConditionType.PROFIT_RATE, sellEvent(1, "10000", "0"))).isZero();
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = MissionConditionType.class, mode = EnumSource.Mode.EXCLUDE,
+            names = {"TRADE_COUNT", "BUY_COUNT", "SELL_COUNT", "DAILY_TRADE_COUNT",
+                    "BUY_AMOUNT", "SELL_AMOUNT", "TOTAL_TRADE_AMOUNT", "DAILY_PROFIT_COUNT", "PROFIT_RATE"})
+    void 누적형이_아닌_조건의_증가값은_0이다(MissionConditionType type) {
+        assertThat(calculator.calculateIncreaseValue(type, sellEvent(1, "12000", "10000"))).isZero();
+    }
+
+    // --- calculateThresholdValue: 달성형 분기표 ---
+
+    @Test
+    void 달성형_계산은_SELL이_아니면_무조건_0이다() {
+        assertThat(calculator.calculateThresholdValue(
+                MissionConditionType.PROFIT_AMOUNT, buyEvent(1, "10000"))).isZero();
+        assertThat(calculator.calculateThresholdValue(
+                MissionConditionType.PROFIT_RATE, buyEvent(1, "10000"))).isZero();
+    }
+
+    @Test
+    void 달성형_수익률은_HALF_UP_반올림되고_평단가_0이면_0이다() {
+        // 4.9% -> 5
+        assertThat(calculator.calculateThresholdValue(
+                MissionConditionType.PROFIT_RATE, sellEvent(1, "10490", "10000"))).isEqualTo(5);
+        // 4.4% -> 4
+        assertThat(calculator.calculateThresholdValue(
+                MissionConditionType.PROFIT_RATE, sellEvent(1, "10440", "10000"))).isEqualTo(4);
+        // 손실 -10% -> -10
+        assertThat(calculator.calculateThresholdValue(
+                MissionConditionType.PROFIT_RATE, sellEvent(1, "9000", "10000"))).isEqualTo(-10);
+        // 평단가 0 -> 0
+        assertThat(calculator.calculateThresholdValue(
+                MissionConditionType.PROFIT_RATE, sellEvent(1, "10000", "0"))).isZero();
+    }
+
+    @Test
+    void 달성형_수익금은_체결금액에서_매입원가를_뺀_정수부다() {
+        // (12,000 x 2) - (10,000 x 2) = 4,000
+        assertThat(calculator.calculateThresholdValue(
+                MissionConditionType.PROFIT_AMOUNT, sellEvent(2, "12000", "10000"))).isEqualTo(4000);
+        // 손실이면 음수 그대로: (9,000 x 2) - (10,000 x 2) = -2,000
+        assertThat(calculator.calculateThresholdValue(
+                MissionConditionType.PROFIT_AMOUNT, sellEvent(2, "9000", "10000"))).isEqualTo(-2000);
+    }
+
+    @Test
+    void 달성형이_아닌_조건은_SELL이어도_0이다() {
+        assertThat(calculator.calculateThresholdValue(
+                MissionConditionType.TRADE_COUNT, sellEvent(1, "12000", "10000"))).isZero();
+        assertThat(calculator.calculateThresholdValue(
+                MissionConditionType.HOLDING_DAYS, sellEvent(1, "12000", "10000"))).isZero();
+    }
+
+    // --- calculateScoreFromProfit: sqrt(profit/10), 0 이하 -> 0 ---
+
+    @Test
+    void 수익금_점수환산은_sqrt_profit_나누기10이고_0이하는_0이다() {
+        assertThat(calculator.calculateScoreFromProfit(-500)).isZero();
+        assertThat(calculator.calculateScoreFromProfit(0)).isZero();
+        // 특성화: 1 -> sqrt(0.1) = 0.316 -> 0 (int 절사)
+        assertThat(calculator.calculateScoreFromProfit(1)).isZero();
+        // 10 -> sqrt(1) = 1
+        assertThat(calculator.calculateScoreFromProfit(10)).isEqualTo(1);
+        // 1,000 -> sqrt(100) = 10
+        assertThat(calculator.calculateScoreFromProfit(1000)).isEqualTo(10);
+        // 특성화: 절사 — 3,599 -> sqrt(359.9) = 18.97 -> 18
+        assertThat(calculator.calculateScoreFromProfit(3599)).isEqualTo(18);
+    }
+}

--- a/src/test/java/grit/stockIt/domain/mission/service/MissionQueryIntegrationTest.java
+++ b/src/test/java/grit/stockIt/domain/mission/service/MissionQueryIntegrationTest.java
@@ -19,8 +19,8 @@ import grit.stockIt.domain.mission.entity.Reward;
 import grit.stockIt.domain.mission.enums.MissionStatus;
 import grit.stockIt.domain.mission.repository.MissionProgressRepository;
 import grit.stockIt.domain.mission.repository.MissionRepository;
-import grit.stockIt.domain.ranking.service.RankingService;
 import grit.stockIt.global.support.IntegrationTestSupport;
+import jakarta.persistence.EntityNotFoundException;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
@@ -28,11 +28,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.jdbc.Sql;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * [특성화 테스트] MissionService 조회/API 계약(AC8 근거)의 현재 응답 값을 그대로 고정한다.
+ * [특성화 테스트] 미션 조회/API 계약(AC8 근거)의 현재 응답 값을 그대로 고정한다.
+ * B-2 이후 조회 4종(getMissionDashboard/getMissionsByTrack/getMyTitles/getTierInfo)은
+ * MissionQueryService를, 쓰기 액션(claimDailyAttendance/applyForBankruptcy)은 MissionService를 표적한다.
  * 리팩토링 전 안전망이므로 "이상해 보이는" 동작(잘못된 track -> 빈 목록, 파산 기준 100만원 등)도
  * 관찰된 그대로 단언하고 수정하지 않는다.
  */
@@ -52,7 +53,7 @@ class MissionQueryIntegrationTest extends IntegrationTestSupport {
     private MissionService missionService;
 
     @Autowired
-    private RankingService rankingService;
+    private MissionQueryService missionQueryService;
 
     @Autowired
     private MemberRepository memberRepository;
@@ -76,7 +77,7 @@ class MissionQueryIntegrationTest extends IntegrationTestSupport {
     void getMissionDashboard_신규회원은_연속출석0_남은일일미션4() {
         Member member = createMemberWithMissions();
 
-        MissionDashboardResponse response = missionService.getMissionDashboard(member.getEmail());
+        MissionDashboardResponse response = missionQueryService.getMissionDashboard(member.getEmail());
 
         assertThat(response.getConsecutiveAttendanceDays()).isZero();
         assertThat(response.getRemainingDailyMissions()).isEqualTo(4);
@@ -88,7 +89,7 @@ class MissionQueryIntegrationTest extends IntegrationTestSupport {
         Member member = createMemberWithMissions();
         missionService.claimDailyAttendance(member.getEmail());
 
-        MissionDashboardResponse response = missionService.getMissionDashboard(member.getEmail());
+        MissionDashboardResponse response = missionQueryService.getMissionDashboard(member.getEmail());
 
         // 특성화: goalValue가 가장 큰 LOGIN_STREAK 미션(900, 목표 100,000)의 현재값이 연속 출석 일수
         assertThat(response.getConsecutiveAttendanceDays()).isEqualTo(1);
@@ -103,9 +104,9 @@ class MissionQueryIntegrationTest extends IntegrationTestSupport {
         Member member = createMemberWithMissions();
 
         // 특성화: data.sql 기준 DAILY 4 + ACHIEVEMENT 13(트래커 900/998/999 포함) + 트랙 12 = 29
-        assertThat(missionService.getMissionsByTrack(member.getEmail(), "ALL")).hasSize(29);
-        assertThat(missionService.getMissionsByTrack(member.getEmail(), "all")).hasSize(29);
-        assertThat(missionService.getMissionsByTrack(member.getEmail(), null)).hasSize(29);
+        assertThat(missionQueryService.getMissionsByTrack(member.getEmail(), "ALL")).hasSize(29);
+        assertThat(missionQueryService.getMissionsByTrack(member.getEmail(), "all")).hasSize(29);
+        assertThat(missionQueryService.getMissionsByTrack(member.getEmail(), null)).hasSize(29);
     }
 
     @Test
@@ -113,7 +114,7 @@ class MissionQueryIntegrationTest extends IntegrationTestSupport {
     void getMissionsByTrack_DAILY_필터와_응답필드값() {
         Member member = createMemberWithMissions();
 
-        List<MissionListResponse> daily = missionService.getMissionsByTrack(member.getEmail(), "DAILY");
+        List<MissionListResponse> daily = missionQueryService.getMissionsByTrack(member.getEmail(), "DAILY");
 
         assertThat(daily).hasSize(4);
         assertThat(daily).allMatch(m -> "DAILY".equals(m.getTrack()));
@@ -136,7 +137,7 @@ class MissionQueryIntegrationTest extends IntegrationTestSupport {
     void getMissionsByTrack_ACHIEVEMENT_필터와_칭호설명_매핑() {
         Member member = createMemberWithMissions();
 
-        List<MissionListResponse> achievements = missionService.getMissionsByTrack(member.getEmail(), "ACHIEVEMENT");
+        List<MissionListResponse> achievements = missionQueryService.getMissionsByTrack(member.getEmail(), "ACHIEVEMENT");
 
         assertThat(achievements).hasSize(13);
 
@@ -164,7 +165,7 @@ class MissionQueryIntegrationTest extends IntegrationTestSupport {
     void getMissionsByTrack_소문자_트랙명도_필터링된다() {
         Member member = createMemberWithMissions();
 
-        assertThat(missionService.getMissionsByTrack(member.getEmail(), "daily")).hasSize(4);
+        assertThat(missionQueryService.getMissionsByTrack(member.getEmail(), "daily")).hasSize(4);
     }
 
     @Test
@@ -172,8 +173,8 @@ class MissionQueryIntegrationTest extends IntegrationTestSupport {
     void getMissionsByTrack_잘못된_트랙명은_빈목록을_반환한다() {
         Member member = createMemberWithMissions();
 
-        // 특성화: MissionService L610~617 — IllegalArgumentException을 삼키고 List.of() 반환, 버그 의심
-        assertThat(missionService.getMissionsByTrack(member.getEmail(), "NOT_A_TRACK")).isEmpty();
+        // 특성화: MissionQueryService.getMissionsByTrack — IllegalArgumentException을 삼키고 List.of() 반환, 버그 의심
+        assertThat(missionQueryService.getMissionsByTrack(member.getEmail(), "NOT_A_TRACK")).isEmpty();
     }
 
     // --- 6. getMyTitles / getTierInfo / claimDailyAttendance / applyForBankruptcy ---
@@ -183,7 +184,7 @@ class MissionQueryIntegrationTest extends IntegrationTestSupport {
     void getMyTitles_신규회원은_빈목록() {
         Member member = createMemberWithMissions();
 
-        assertThat(missionService.getMyTitles(member.getEmail())).isEmpty();
+        assertThat(missionQueryService.getMyTitles(member.getEmail())).isEmpty();
     }
 
     @Test
@@ -191,7 +192,7 @@ class MissionQueryIntegrationTest extends IntegrationTestSupport {
     void getTierInfo_신규회원은_활동점수1200으로_SILVER1() {
         Member member = createMemberWithMissions();
 
-        UserTierStatusResponse tier = missionService.getTierInfo(member.getEmail());
+        UserTierStatusResponse tier = missionQueryService.getTierInfo(member.getEmail());
 
         // 특성화: 활동 점수 트래커(998) 초기값 1200으로 신규 회원은 SILVER 1에서 시작
         assertThat(tier.getCurrentTier()).isEqualTo("SILVER 1");
@@ -210,7 +211,7 @@ class MissionQueryIntegrationTest extends IntegrationTestSupport {
         progressOf(member, SKILL_SCORE_TRACKER_ID).setCurrentValue(1000);
         missionProgressRepository.flush();
 
-        UserTierStatusResponse tier = missionService.getTierInfo(member.getEmail());
+        UserTierStatusResponse tier = missionQueryService.getTierInfo(member.getEmail());
 
         // 특성화: sqrt(1000 / 10) = 10점
         assertThat(tier.getSkillScore()).isEqualTo(10);
@@ -222,7 +223,7 @@ class MissionQueryIntegrationTest extends IntegrationTestSupport {
         // 누적 손실이면 실력 점수 0
         progressOf(member, SKILL_SCORE_TRACKER_ID).setCurrentValue(-500);
         missionProgressRepository.flush();
-        assertThat(missionService.getTierInfo(member.getEmail()).getSkillScore()).isZero();
+        assertThat(missionQueryService.getTierInfo(member.getEmail()).getSkillScore()).isZero();
     }
 
     @Test
@@ -232,7 +233,7 @@ class MissionQueryIntegrationTest extends IntegrationTestSupport {
         progressOf(member, ACTIVITY_SCORE_TRACKER_ID).setCurrentValue(3600);
         missionProgressRepository.flush();
 
-        UserTierStatusResponse tier = missionService.getTierInfo(member.getEmail());
+        UserTierStatusResponse tier = missionQueryService.getTierInfo(member.getEmail());
 
         assertThat(tier.getCurrentTier()).isEqualTo("LEGEND");
         assertThat(tier.getNextTier()).isEqualTo("MAX");
@@ -318,12 +319,12 @@ class MissionQueryIntegrationTest extends IntegrationTestSupport {
         assertThat(progressOf(member, SKILL_SCORE_TRACKER_ID).getCurrentValue()).isZero();
 
         // 칭호 획득 반영
-        List<MemberTitleResponse> titles = missionService.getMyTitles(member.getEmail());
+        List<MemberTitleResponse> titles = missionQueryService.getMyTitles(member.getEmail());
         assertThat(titles).hasSize(1);
         assertThat(titles.get(0).getName()).isEqualTo("인생 2회차");
 
         // 특성화: 점수 초기화로 BRONZE 1 / 총점 0으로 강등
-        UserTierStatusResponse tier = missionService.getTierInfo(member.getEmail());
+        UserTierStatusResponse tier = missionQueryService.getTierInfo(member.getEmail());
         assertThat(tier.getCurrentTier()).isEqualTo("BRONZE 1");
         assertThat(tier.getTotalScore()).isZero();
         assertThat(tier.getScoreToNextTier()).isEqualTo(800);
@@ -347,35 +348,29 @@ class MissionQueryIntegrationTest extends IntegrationTestSupport {
                 .hasMessage("이미 구조 지원금을 받으셨습니다.");
     }
 
-    // --- 7. RankingService.getTierForMember 경유 계약 ---
-    // 리플렉션 사용 사유: getTierForMember는 private이고 유일한 공개 경유는 @Scheduled 배치라 flaky.
-    // A-4의 '리플렉션 금지'는 순수 계산 로직 특성화에 한정된 제약이며, 이 계약은 B-2에서
-    // MissionQueryService 공개 계약 테스트로 승격 예정(승인된 계획 Verification Plan 'B-2 후' 항목).
+    // --- 7. RankingService.getTierForMember 경유 계약 (B-2 승격) ---
+    // Phase A의 리플렉션 특성화를 계획(Verification Plan 'B-2 후')대로 MissionQueryService 공개 계약으로 승격.
+    // getTierForMember는 missionQueryService.getTierInfo(email).getCurrentTier()를 사용하고,
+    // 조회 예외는 catch하여 null 폴백한다 — 그 전제(반환 티어 문자열 / 미존재 회원 예외)를 고정한다.
 
     @Test
-    @DisplayName("RankingService.getTierForMember: 정상 조회 시 현재 티어 문자열을 반환한다")
-    void getTierForMember_정상조회시_현재티어_문자열을_반환한다() {
+    @DisplayName("getTierForMember가 의존하는 공개 계약: getTierInfo는 현재 티어 문자열을 반환한다")
+    void getTierForMember_공개계약_정상조회시_현재티어_문자열을_반환한다() {
         Member member = createMemberWithMissions();
 
-        String tier = ReflectionTestUtils.invokeMethod(rankingService, "getTierForMember", member);
+        String tier = missionQueryService.getTierInfo(member.getEmail()).getCurrentTier();
 
         assertThat(tier).isEqualTo("SILVER 1");
     }
 
     @Test
-    @DisplayName("RankingService.getTierForMember: 조회 실패 시 예외를 삼키고 null을 반환한다")
-    void getTierForMember_조회실패시_null을_반환한다() {
-        // DB에 존재하지 않는 이메일을 가진 비영속 회원
-        Member ghost = Member.builder()
-                .name("ghost")
-                .email("ghost-" + UUID.randomUUID() + "@test.com")
-                .provider(AuthProvider.LOCAL)
-                .build();
+    @DisplayName("getTierForMember가 의존하는 공개 계약: 미존재 회원 조회는 EntityNotFoundException을 던진다")
+    void getTierForMember_공개계약_미존재회원이면_EntityNotFoundException이_발생한다() {
+        // 특성화: RankingService.getTierForMember는 이 예외를 catch하여 경고 로그 후 null 폴백한다
+        String ghostEmail = "ghost-" + UUID.randomUUID() + "@test.com";
 
-        // 특성화: RankingService L279~287 — EntityNotFoundException을 catch하여 경고 로그 후 null 폴백
-        String tier = ReflectionTestUtils.invokeMethod(rankingService, "getTierForMember", ghost);
-
-        assertThat(tier).isNull();
+        assertThatThrownBy(() -> missionQueryService.getTierInfo(ghostEmail))
+                .isInstanceOf(EntityNotFoundException.class);
     }
 
     // --- 헬퍼 (슬라이스 자체 소유, 다른 테스트와 공유하지 않음) ---

--- a/src/test/java/grit/stockIt/domain/mission/service/MissionQueryIntegrationTest.java
+++ b/src/test/java/grit/stockIt/domain/mission/service/MissionQueryIntegrationTest.java
@@ -348,6 +348,9 @@ class MissionQueryIntegrationTest extends IntegrationTestSupport {
     }
 
     // --- 7. RankingService.getTierForMember 경유 계약 ---
+    // 리플렉션 사용 사유: getTierForMember는 private이고 유일한 공개 경유는 @Scheduled 배치라 flaky.
+    // A-4의 '리플렉션 금지'는 순수 계산 로직 특성화에 한정된 제약이며, 이 계약은 B-2에서
+    // MissionQueryService 공개 계약 테스트로 승격 예정(승인된 계획 Verification Plan 'B-2 후' 항목).
 
     @Test
     @DisplayName("RankingService.getTierForMember: 정상 조회 시 현재 티어 문자열을 반환한다")

--- a/src/test/java/grit/stockIt/domain/mission/service/MissionQueryIntegrationTest.java
+++ b/src/test/java/grit/stockIt/domain/mission/service/MissionQueryIntegrationTest.java
@@ -1,0 +1,398 @@
+package grit.stockIt.domain.mission.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import grit.stockIt.domain.account.entity.Account;
+import grit.stockIt.domain.account.repository.AccountRepository;
+import grit.stockIt.domain.account.service.AccountService;
+import grit.stockIt.domain.member.entity.AuthProvider;
+import grit.stockIt.domain.member.entity.Member;
+import grit.stockIt.domain.member.repository.MemberRepository;
+import grit.stockIt.domain.mission.dto.MemberTitleResponse;
+import grit.stockIt.domain.mission.dto.MissionDashboardResponse;
+import grit.stockIt.domain.mission.dto.MissionListResponse;
+import grit.stockIt.domain.mission.dto.UserTierStatusResponse;
+import grit.stockIt.domain.mission.entity.Mission;
+import grit.stockIt.domain.mission.entity.MissionProgress;
+import grit.stockIt.domain.mission.entity.Reward;
+import grit.stockIt.domain.mission.enums.MissionStatus;
+import grit.stockIt.domain.mission.repository.MissionProgressRepository;
+import grit.stockIt.domain.mission.repository.MissionRepository;
+import grit.stockIt.domain.ranking.service.RankingService;
+import grit.stockIt.global.support.IntegrationTestSupport;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * [특성화 테스트] MissionService 조회/API 계약(AC8 근거)의 현재 응답 값을 그대로 고정한다.
+ * 리팩토링 전 안전망이므로 "이상해 보이는" 동작(잘못된 track -> 빈 목록, 파산 기준 100만원 등)도
+ * 관찰된 그대로 단언하고 수정하지 않는다.
+ */
+@Transactional
+@Sql("/data.sql")
+class MissionQueryIntegrationTest extends IntegrationTestSupport {
+
+    private static final long DAILY_ATTENDANCE_ID = 101L;
+    private static final long SEED_COPIER_ID = 901L;
+    private static final long STREAK_TRACKER_ID = 900L;
+    private static final long STREAK_7D_ID = 906L;
+    private static final long BANKRUPTCY_ID = 911L;
+    private static final long ACTIVITY_SCORE_TRACKER_ID = 998L;
+    private static final long SKILL_SCORE_TRACKER_ID = 999L;
+
+    @Autowired
+    private MissionService missionService;
+
+    @Autowired
+    private RankingService rankingService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private AccountService accountService;
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    @Autowired
+    private MissionRepository missionRepository;
+
+    @Autowired
+    private MissionProgressRepository missionProgressRepository;
+
+    // --- 4. getMissionDashboard ---
+
+    @Test
+    @DisplayName("신규 회원의 대시보드: 연속 출석 0일, 남은 일일 미션 4개")
+    void getMissionDashboard_신규회원은_연속출석0_남은일일미션4() {
+        Member member = createMemberWithMissions();
+
+        MissionDashboardResponse response = missionService.getMissionDashboard(member.getEmail());
+
+        assertThat(response.getConsecutiveAttendanceDays()).isZero();
+        assertThat(response.getRemainingDailyMissions()).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("출석 완료 후 대시보드: 연속 출석 1일(트래커 900 기준), 남은 일일 미션 3개")
+    void getMissionDashboard_출석완료후_연속출석1_남은미션3() {
+        Member member = createMemberWithMissions();
+        missionService.claimDailyAttendance(member.getEmail());
+
+        MissionDashboardResponse response = missionService.getMissionDashboard(member.getEmail());
+
+        // 특성화: goalValue가 가장 큰 LOGIN_STREAK 미션(900, 목표 100,000)의 현재값이 연속 출석 일수
+        assertThat(response.getConsecutiveAttendanceDays()).isEqualTo(1);
+        assertThat(response.getRemainingDailyMissions()).isEqualTo(3);
+    }
+
+    // --- 5. getMissionsByTrack ---
+
+    @Test
+    @DisplayName("track=ALL 또는 null이면 회원의 전체 미션 진행도 29건을 반환한다")
+    void getMissionsByTrack_ALL과_null은_전체_29건을_반환한다() {
+        Member member = createMemberWithMissions();
+
+        // 특성화: data.sql 기준 DAILY 4 + ACHIEVEMENT 13(트래커 900/998/999 포함) + 트랙 12 = 29
+        assertThat(missionService.getMissionsByTrack(member.getEmail(), "ALL")).hasSize(29);
+        assertThat(missionService.getMissionsByTrack(member.getEmail(), "all")).hasSize(29);
+        assertThat(missionService.getMissionsByTrack(member.getEmail(), null)).hasSize(29);
+    }
+
+    @Test
+    @DisplayName("track=DAILY 필터링과 응답 필드 값 고정 (출석체크 미션 101)")
+    void getMissionsByTrack_DAILY_필터와_응답필드값() {
+        Member member = createMemberWithMissions();
+
+        List<MissionListResponse> daily = missionService.getMissionsByTrack(member.getEmail(), "DAILY");
+
+        assertThat(daily).hasSize(4);
+        assertThat(daily).allMatch(m -> "DAILY".equals(m.getTrack()));
+
+        MissionListResponse attendance = daily.stream()
+                .filter(m -> m.getId() == DAILY_ATTENDANCE_ID)
+                .findFirst().orElseThrow();
+        assertThat(attendance.getTitle()).isEqualTo("출석체크하기");
+        // 특성화: ACHIEVEMENT가 아니면 description은 미션 이름 그대로
+        assertThat(attendance.getDescription()).isEqualTo("출석체크하기");
+        assertThat(attendance.getCurrentValue()).isZero();
+        assertThat(attendance.getGoalValue()).isEqualTo(1);
+        assertThat(attendance.isCompleted()).isFalse();
+        assertThat(attendance.getRewardMoney()).isEqualTo(150000L);
+        assertThat(attendance.getRewardTitle()).isNull();
+    }
+
+    @Test
+    @DisplayName("track=ACHIEVEMENT 필터: 13건, 칭호 설명 매핑 및 보상 없는 트래커 미션 응답 고정")
+    void getMissionsByTrack_ACHIEVEMENT_필터와_칭호설명_매핑() {
+        Member member = createMemberWithMissions();
+
+        List<MissionListResponse> achievements = missionService.getMissionsByTrack(member.getEmail(), "ACHIEVEMENT");
+
+        assertThat(achievements).hasSize(13);
+
+        // 특성화: ACHIEVEMENT + 칭호 보상이면 description은 칭호 설명으로 대체
+        MissionListResponse seedCopier = achievements.stream()
+                .filter(m -> m.getId() == SEED_COPIER_ID)
+                .findFirst().orElseThrow();
+        assertThat(seedCopier.getTitle()).isEqualTo("시드 콜로니");
+        assertThat(seedCopier.getDescription()).isEqualTo("누적 미션 30회 완료한 자");
+        assertThat(seedCopier.getRewardMoney()).isEqualTo(15000000L);
+        assertThat(seedCopier.getRewardTitle()).isEqualTo("시드 콜로니");
+
+        // 특성화: 활동 점수 트래커(998)도 목록에 노출됨 (초기값 1200, 보상 없음)
+        MissionListResponse activityTracker = achievements.stream()
+                .filter(m -> m.getId() == ACTIVITY_SCORE_TRACKER_ID)
+                .findFirst().orElseThrow();
+        assertThat(activityTracker.getDescription()).isEqualTo("활동 점수 트래커");
+        assertThat(activityTracker.getCurrentValue()).isEqualTo(1200);
+        assertThat(activityTracker.getRewardMoney()).isZero();
+        assertThat(activityTracker.getRewardTitle()).isNull();
+    }
+
+    @Test
+    @DisplayName("소문자 트랙명(daily)도 대문자로 변환되어 필터링된다")
+    void getMissionsByTrack_소문자_트랙명도_필터링된다() {
+        Member member = createMemberWithMissions();
+
+        assertThat(missionService.getMissionsByTrack(member.getEmail(), "daily")).hasSize(4);
+    }
+
+    @Test
+    @DisplayName("정의되지 않은 track 문자열이면 예외 없이 빈 목록을 반환한다")
+    void getMissionsByTrack_잘못된_트랙명은_빈목록을_반환한다() {
+        Member member = createMemberWithMissions();
+
+        // 특성화: MissionService L610~617 — IllegalArgumentException을 삼키고 List.of() 반환, 버그 의심
+        assertThat(missionService.getMissionsByTrack(member.getEmail(), "NOT_A_TRACK")).isEmpty();
+    }
+
+    // --- 6. getMyTitles / getTierInfo / claimDailyAttendance / applyForBankruptcy ---
+
+    @Test
+    @DisplayName("신규 회원의 보유 칭호는 빈 목록이다")
+    void getMyTitles_신규회원은_빈목록() {
+        Member member = createMemberWithMissions();
+
+        assertThat(missionService.getMyTitles(member.getEmail())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("신규 회원의 티어: 활동 1200 + 실력 0 = SILVER 1, 다음 티어까지 200점, 진행도 0%")
+    void getTierInfo_신규회원은_활동점수1200으로_SILVER1() {
+        Member member = createMemberWithMissions();
+
+        UserTierStatusResponse tier = missionService.getTierInfo(member.getEmail());
+
+        // 특성화: 활동 점수 트래커(998) 초기값 1200으로 신규 회원은 SILVER 1에서 시작
+        assertThat(tier.getCurrentTier()).isEqualTo("SILVER 1");
+        assertThat(tier.getNextTier()).isEqualTo("SILVER 2");
+        assertThat(tier.getActivityScore()).isEqualTo(1200);
+        assertThat(tier.getSkillScore()).isZero();
+        assertThat(tier.getTotalScore()).isEqualTo(1200);
+        assertThat(tier.getScoreToNextTier()).isEqualTo(200);
+        assertThat(tier.getProgressPercentage()).isEqualTo(0.0);
+    }
+
+    @Test
+    @DisplayName("실력 점수는 누적 수익금(999 트래커)의 sqrt(profit/10)로 환산되고, 손실이면 0점이다")
+    void getTierInfo_실력점수는_수익금의_제곱근으로_환산된다() {
+        Member member = createMemberWithMissions();
+        progressOf(member, SKILL_SCORE_TRACKER_ID).setCurrentValue(1000);
+        missionProgressRepository.flush();
+
+        UserTierStatusResponse tier = missionService.getTierInfo(member.getEmail());
+
+        // 특성화: sqrt(1000 / 10) = 10점
+        assertThat(tier.getSkillScore()).isEqualTo(10);
+        assertThat(tier.getTotalScore()).isEqualTo(1210);
+        assertThat(tier.getCurrentTier()).isEqualTo("SILVER 1");
+        assertThat(tier.getScoreToNextTier()).isEqualTo(190);
+        assertThat(tier.getProgressPercentage()).isEqualTo(5.0);
+
+        // 누적 손실이면 실력 점수 0
+        progressOf(member, SKILL_SCORE_TRACKER_ID).setCurrentValue(-500);
+        missionProgressRepository.flush();
+        assertThat(missionService.getTierInfo(member.getEmail()).getSkillScore()).isZero();
+    }
+
+    @Test
+    @DisplayName("총점 3600 이상이면 LEGEND: nextTier=MAX, 남은 점수 0, 진행도 100%")
+    void getTierInfo_LEGEND_도달시_nextTier_MAX_진행도100() {
+        Member member = createMemberWithMissions();
+        progressOf(member, ACTIVITY_SCORE_TRACKER_ID).setCurrentValue(3600);
+        missionProgressRepository.flush();
+
+        UserTierStatusResponse tier = missionService.getTierInfo(member.getEmail());
+
+        assertThat(tier.getCurrentTier()).isEqualTo("LEGEND");
+        assertThat(tier.getNextTier()).isEqualTo("MAX");
+        assertThat(tier.getTotalScore()).isEqualTo(3600);
+        // 특성화: LEGEND는 목표치를 현재 점수와 동일시하여 남은 점수 0
+        assertThat(tier.getScoreToNextTier()).isZero();
+        assertThat(tier.getProgressPercentage()).isEqualTo(100.0);
+    }
+
+    @Test
+    @DisplayName("출석 보상 수령: 15만원 지급·미션 완료·연속 출석 연쇄 갱신·활동 점수 +10")
+    void claimDailyAttendance_보상지급과_연쇄효과를_고정한다() {
+        Member member = createMemberWithMissions();
+        Account account = accountRepository.findByMemberAndIsDefaultTrue(member).orElseThrow();
+        BigDecimal cashBefore = account.getCash();
+
+        Reward reward = missionService.claimDailyAttendance(member.getEmail());
+
+        assertThat(reward.getMoneyAmount()).isEqualTo(150000L);
+        assertThat(reward.getTitleToGrant()).isNull();
+        assertThat(account.getCash()).isEqualByComparingTo(cashBefore.add(BigDecimal.valueOf(150000)));
+
+        MissionProgress attendance = progressOf(member, DAILY_ATTENDANCE_ID);
+        assertThat(attendance.getCurrentValue()).isEqualTo(1);
+        assertThat(attendance.getStatus()).isEqualTo(MissionStatus.COMPLETED);
+
+        // 연쇄: LOGIN_STREAK 계열(트래커 900 포함) +1
+        assertThat(progressOf(member, STREAK_TRACKER_ID).getCurrentValue()).isEqualTo(1);
+        assertThat(progressOf(member, STREAK_7D_ID).getCurrentValue()).isEqualTo(1);
+
+        // 연쇄: 시드 콜로니(901) 진행도 = 완료 미션 수(1)
+        assertThat(progressOf(member, SEED_COPIER_ID).getCurrentValue()).isEqualTo(1);
+
+        // 특성화: 미션 완료 시 활동 점수 트래커(998) 1200 -> 1210
+        assertThat(progressOf(member, ACTIVITY_SCORE_TRACKER_ID).getCurrentValue()).isEqualTo(1210);
+    }
+
+    @Test
+    @DisplayName("출석 보상을 이미 받았으면 IllegalStateException이 발생한다")
+    void claimDailyAttendance_중복호출시_예외가_발생한다() {
+        Member member = createMemberWithMissions();
+        missionService.claimDailyAttendance(member.getEmail());
+
+        assertThatThrownBy(() -> missionService.claimDailyAttendance(member.getEmail()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("오늘은 이미 출석 보상을 받았습니다.");
+    }
+
+    @Test
+    @DisplayName("총 자산 100만원 이상이면 파산 신청이 거절된다 (API 문구는 5만원이지만 코드는 100만원 기준)")
+    void applyForBankruptcy_자산이_100만원_이상이면_예외가_발생한다() {
+        Member member = createMemberWithMissions();
+        Account account = accountRepository.findByMemberAndIsDefaultTrue(member).orElseThrow();
+        // 특성화: 경계값 100만원 정확히 보유해도 거절됨 (>= 비교). 칭호/스웨거 설명(5만원)과 불일치, 버그 의심
+        account.setCash(BigDecimal.valueOf(1000000));
+        accountRepository.flush();
+
+        assertThatThrownBy(() -> missionService.applyForBankruptcy(member.getEmail()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageStartingWith("아직 파산할 정도로 돈이 없지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("파산 승인: 2천만원+칭호 지급, 미션 완료, 활동/실력 점수 0 초기화 후 BRONZE 1 강등")
+    void applyForBankruptcy_승인시_보상지급과_티어점수_초기화() {
+        Member member = createMemberWithMissions();
+        Account account = accountRepository.findByMemberAndIsDefaultTrue(member).orElseThrow();
+        account.setCash(BigDecimal.valueOf(50000));
+        accountRepository.flush();
+
+        Reward reward = missionService.applyForBankruptcy(member.getEmail());
+
+        assertThat(reward.getMoneyAmount()).isEqualTo(20000000L);
+        assertThat(reward.getTitleToGrant().getName()).isEqualTo("인생 2회차");
+        assertThat(account.getCash()).isEqualByComparingTo(BigDecimal.valueOf(20050000));
+
+        MissionProgress bankruptcy = progressOf(member, BANKRUPTCY_ID);
+        assertThat(bankruptcy.getStatus()).isEqualTo(MissionStatus.COMPLETED);
+        assertThat(bankruptcy.getCurrentValue()).isEqualTo(1000000);
+
+        // 티어 점수 완전 초기화
+        assertThat(progressOf(member, ACTIVITY_SCORE_TRACKER_ID).getCurrentValue()).isZero();
+        assertThat(progressOf(member, SKILL_SCORE_TRACKER_ID).getCurrentValue()).isZero();
+
+        // 칭호 획득 반영
+        List<MemberTitleResponse> titles = missionService.getMyTitles(member.getEmail());
+        assertThat(titles).hasSize(1);
+        assertThat(titles.get(0).getName()).isEqualTo("인생 2회차");
+
+        // 특성화: 점수 초기화로 BRONZE 1 / 총점 0으로 강등
+        UserTierStatusResponse tier = missionService.getTierInfo(member.getEmail());
+        assertThat(tier.getCurrentTier()).isEqualTo("BRONZE 1");
+        assertThat(tier.getTotalScore()).isZero();
+        assertThat(tier.getScoreToNextTier()).isEqualTo(800);
+    }
+
+    @Test
+    @DisplayName("이미 파산 보상을 받았으면 재신청 시 IllegalStateException이 발생한다")
+    void applyForBankruptcy_중복신청시_예외가_발생한다() {
+        Member member = createMemberWithMissions();
+        Account account = accountRepository.findByMemberAndIsDefaultTrue(member).orElseThrow();
+        account.setCash(BigDecimal.valueOf(50000));
+        accountRepository.flush();
+        missionService.applyForBankruptcy(member.getEmail());
+
+        // 자산 검증이 완료 검증보다 먼저이므로, 다시 빈털터리로 만들어야 중복 분기에 도달한다
+        account.setCash(BigDecimal.valueOf(40000));
+        accountRepository.flush();
+
+        assertThatThrownBy(() -> missionService.applyForBankruptcy(member.getEmail()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("이미 구조 지원금을 받으셨습니다.");
+    }
+
+    // --- 7. RankingService.getTierForMember 경유 계약 ---
+
+    @Test
+    @DisplayName("RankingService.getTierForMember: 정상 조회 시 현재 티어 문자열을 반환한다")
+    void getTierForMember_정상조회시_현재티어_문자열을_반환한다() {
+        Member member = createMemberWithMissions();
+
+        String tier = ReflectionTestUtils.invokeMethod(rankingService, "getTierForMember", member);
+
+        assertThat(tier).isEqualTo("SILVER 1");
+    }
+
+    @Test
+    @DisplayName("RankingService.getTierForMember: 조회 실패 시 예외를 삼키고 null을 반환한다")
+    void getTierForMember_조회실패시_null을_반환한다() {
+        // DB에 존재하지 않는 이메일을 가진 비영속 회원
+        Member ghost = Member.builder()
+                .name("ghost")
+                .email("ghost-" + UUID.randomUUID() + "@test.com")
+                .provider(AuthProvider.LOCAL)
+                .build();
+
+        // 특성화: RankingService L279~287 — EntityNotFoundException을 catch하여 경고 로그 후 null 폴백
+        String tier = ReflectionTestUtils.invokeMethod(rankingService, "getTierForMember", ghost);
+
+        assertThat(tier).isNull();
+    }
+
+    // --- 헬퍼 (슬라이스 자체 소유, 다른 테스트와 공유하지 않음) ---
+
+    private Member createMemberWithMissions() {
+        String email = "mission-query-" + UUID.randomUUID() + "@test.com";
+        Member member = memberRepository.save(Member.builder()
+                .name("query-tester")
+                .email(email)
+                .password("password")
+                .provider(AuthProvider.LOCAL)
+                .build());
+        accountService.createDefaultAccountForMember(member);
+        missionService.initializeMissionsForNewMember(member);
+        missionProgressRepository.flush();
+        return member;
+    }
+
+    private MissionProgress progressOf(Member member, long missionId) {
+        Mission mission = missionRepository.findById(missionId).orElseThrow();
+        return missionProgressRepository.findByMemberAndMission(member, mission).orElseThrow();
+    }
+}

--- a/src/test/java/grit/stockIt/domain/mission/service/MissionSchedulerFlowIntegrationTest.java
+++ b/src/test/java/grit/stockIt/domain/mission/service/MissionSchedulerFlowIntegrationTest.java
@@ -55,6 +55,9 @@ class MissionSchedulerFlowIntegrationTest extends IntegrationTestSupport {
     private MissionService missionService;
 
     @Autowired
+    private MissionBatchService missionBatchService;
+
+    @Autowired
     private MemberRepository memberRepository;
 
     @Autowired
@@ -93,7 +96,7 @@ class MissionSchedulerFlowIntegrationTest extends IntegrationTestSupport {
         missionProgressRepository.flush();
 
         // when
-        missionService.checkAndResetAttendanceStreaks();
+        missionBatchService.checkAndResetAttendanceStreaks();
 
         // then: 미출석 회원의 LOGIN_STREAK 계열(트래커 900 포함)은 전부 0으로 벌크 리셋
         assertThat(progressOf(absentee, STREAK_TRACKER_ID).getCurrentValue()).isZero();
@@ -125,7 +128,7 @@ class MissionSchedulerFlowIntegrationTest extends IntegrationTestSupport {
         missionProgressRepository.flush();
 
         // when
-        missionService.resetDailyMissions();
+        missionBatchService.resetDailyMissions();
 
         // then: DAILY 트랙 전체가 0/IN_PROGRESS로 리셋 (완료된 출석 미션 포함)
         assertThat(progressOf(member, DAILY_ATTENDANCE_ID).getCurrentValue()).isZero();
@@ -155,7 +158,7 @@ class MissionSchedulerFlowIntegrationTest extends IntegrationTestSupport {
         missionProgressRepository.flush();
 
         // when
-        missionService.resetDailyMissions();
+        missionBatchService.resetDailyMissions();
 
         // then: IN_PROGRESS 상태의 DAILY_TRADE_COUNT만 리셋되므로 완료본은 보존
         assertThat(progressOf(member, KITING_ACHIEVEMENT_ID).getCurrentValue()).isEqualTo(50);
@@ -174,7 +177,7 @@ class MissionSchedulerFlowIntegrationTest extends IntegrationTestSupport {
         missionProgressRepository.flush();
 
         // when
-        missionService.processDailyHoldingUpdate();
+        missionBatchService.processDailyHoldingUpdate();
 
         // then: 진행 중(IN_PROGRESS)인 홀딩 미션(301, 401)만 +1
         assertThat(progressOf(holder, SWING_HOLDING_2D_ID).getCurrentValue()).isEqualTo(1);
@@ -202,8 +205,8 @@ class MissionSchedulerFlowIntegrationTest extends IntegrationTestSupport {
         missionProgressRepository.flush();
 
         // when: 이틀치 스케줄 실행
-        missionService.processDailyHoldingUpdate();
-        missionService.processDailyHoldingUpdate();
+        missionBatchService.processDailyHoldingUpdate();
+        missionBatchService.processDailyHoldingUpdate();
 
         // then: 301(목표 2)은 완료 전이
         MissionProgress swingHolding = progressOf(holder, SWING_HOLDING_2D_ID);

--- a/src/test/java/grit/stockIt/domain/mission/service/MissionSchedulerFlowIntegrationTest.java
+++ b/src/test/java/grit/stockIt/domain/mission/service/MissionSchedulerFlowIntegrationTest.java
@@ -1,0 +1,258 @@
+package grit.stockIt.domain.mission.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import grit.stockIt.domain.account.entity.Account;
+import grit.stockIt.domain.account.entity.AccountStock;
+import grit.stockIt.domain.account.repository.AccountRepository;
+import grit.stockIt.domain.account.repository.AccountStockRepository;
+import grit.stockIt.domain.account.service.AccountService;
+import grit.stockIt.domain.member.entity.AuthProvider;
+import grit.stockIt.domain.member.entity.Member;
+import grit.stockIt.domain.member.repository.MemberRepository;
+import grit.stockIt.domain.mission.entity.Mission;
+import grit.stockIt.domain.mission.entity.MissionProgress;
+import grit.stockIt.domain.mission.enums.MissionStatus;
+import grit.stockIt.domain.mission.repository.MissionProgressRepository;
+import grit.stockIt.domain.mission.repository.MissionRepository;
+import grit.stockIt.domain.stock.entity.Stock;
+import grit.stockIt.domain.stock.repository.StockRepository;
+import grit.stockIt.global.support.IntegrationTestSupport;
+import java.math.BigDecimal;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * [특성화 테스트] MissionScheduler 진입 경로(자정/자정+1분 스케줄)의 현재 동작을
+ * 서비스 메서드 직접 호출로 고정한다. (스케줄링 자체는 테스트 프로파일에서 비활성)
+ *
+ * 리팩토링 전 안전망이므로 "이상해 보이는" 동작도 관찰된 그대로 단언한다.
+ */
+@Transactional
+@Sql("/data.sql")
+class MissionSchedulerFlowIntegrationTest extends IntegrationTestSupport {
+
+    private static final long DAILY_ATTENDANCE_ID = 101L;
+    private static final long DAILY_REPORT_VIEW_ID = 103L;
+    private static final long SHORT_TERM_FIRST_ID = 201L;
+    private static final long SWING_HOLDING_2D_ID = 301L;
+    private static final long SWING_PROFIT_5PCT_ID = 302L;
+    private static final long SWING_HOLDING_7D_ID = 303L;
+    private static final long LONG_TERM_HOLDING_7D_ID = 401L;
+    private static final long LONG_TERM_HOLDING_16D_ID = 403L;
+    private static final long STREAK_TRACKER_ID = 900L;
+    private static final long STREAK_7D_ID = 906L;
+    private static final long STREAK_15D_ID = 907L;
+    private static final long STREAK_30D_ID = 908L;
+    private static final long KITING_ACHIEVEMENT_ID = 904L;
+    private static final long ACTIVITY_SCORE_TRACKER_ID = 998L;
+
+    @Autowired
+    private MissionService missionService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private AccountService accountService;
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    @Autowired
+    private AccountStockRepository accountStockRepository;
+
+    @Autowired
+    private StockRepository stockRepository;
+
+    @Autowired
+    private MissionRepository missionRepository;
+
+    @Autowired
+    private MissionProgressRepository missionProgressRepository;
+
+    // --- 1. checkAndResetAttendanceStreaks ---
+
+    @Test
+    @DisplayName("출석 미체크 회원의 연속 출석 기록만 0으로 초기화되고, 출석 완료 회원의 기록은 보존된다")
+    void checkAndResetAttendanceStreaks_출석미체크_회원만_스트릭이_리셋된다() {
+        // given: 출석하지 않은 회원 (일일 출석 미션 IN_PROGRESS, 스트릭 5)
+        Member absentee = createMemberWithMissions();
+        progressOf(absentee, STREAK_TRACKER_ID).setCurrentValue(5);
+        progressOf(absentee, STREAK_7D_ID).setCurrentValue(5);
+        progressOf(absentee, STREAK_15D_ID).setCurrentValue(5);
+        progressOf(absentee, STREAK_30D_ID).setCurrentValue(5);
+
+        // given: 출석을 완료한 회원 (연쇄 갱신으로 모든 스트릭 진행도 1)
+        Member attendee = createMemberWithMissions();
+        missionService.claimDailyAttendance(attendee.getEmail());
+        missionProgressRepository.flush();
+
+        // when
+        missionService.checkAndResetAttendanceStreaks();
+
+        // then: 미출석 회원의 LOGIN_STREAK 계열(트래커 900 포함)은 전부 0으로 벌크 리셋
+        assertThat(progressOf(absentee, STREAK_TRACKER_ID).getCurrentValue()).isZero();
+        assertThat(progressOf(absentee, STREAK_7D_ID).getCurrentValue()).isZero();
+        assertThat(progressOf(absentee, STREAK_15D_ID).getCurrentValue()).isZero();
+        assertThat(progressOf(absentee, STREAK_30D_ID).getCurrentValue()).isZero();
+        // 특성화: 리셋은 currentValue만 0으로 만들고 상태(IN_PROGRESS)는 그대로 유지
+        assertThat(progressOf(absentee, STREAK_TRACKER_ID).getStatus()).isEqualTo(MissionStatus.IN_PROGRESS);
+        // 일일 출석 미션 자체는 건드리지 않음
+        assertThat(progressOf(absentee, DAILY_ATTENDANCE_ID).getCurrentValue()).isZero();
+        assertThat(progressOf(absentee, DAILY_ATTENDANCE_ID).getStatus()).isEqualTo(MissionStatus.IN_PROGRESS);
+
+        // then: 출석 완료 회원의 스트릭은 보존
+        assertThat(progressOf(attendee, STREAK_TRACKER_ID).getCurrentValue()).isEqualTo(1);
+        assertThat(progressOf(attendee, STREAK_7D_ID).getCurrentValue()).isEqualTo(1);
+    }
+
+    // --- 2. resetDailyMissions ---
+
+    @Test
+    @DisplayName("일일 미션은 완료 여부와 무관하게 진행도 0/IN_PROGRESS로 초기화되고, 카이팅 업적도 함께 리셋된다")
+    void resetDailyMissions_일일미션_진행도와_상태를_초기화한다() {
+        // given: 출석 완료(101 COMPLETED) + 리포트 미션 일부 진행 + 트랙 미션 진행 + 카이팅 진행
+        Member member = createMemberWithMissions();
+        missionService.claimDailyAttendance(member.getEmail());
+        progressOf(member, DAILY_REPORT_VIEW_ID).setCurrentValue(2);
+        progressOf(member, SHORT_TERM_FIRST_ID).setCurrentValue(3);
+        progressOf(member, KITING_ACHIEVEMENT_ID).setCurrentValue(10);
+        missionProgressRepository.flush();
+
+        // when
+        missionService.resetDailyMissions();
+
+        // then: DAILY 트랙 전체가 0/IN_PROGRESS로 리셋 (완료된 출석 미션 포함)
+        assertThat(progressOf(member, DAILY_ATTENDANCE_ID).getCurrentValue()).isZero();
+        assertThat(progressOf(member, DAILY_ATTENDANCE_ID).getStatus()).isEqualTo(MissionStatus.IN_PROGRESS);
+        assertThat(progressOf(member, DAILY_REPORT_VIEW_ID).getCurrentValue()).isZero();
+        assertThat(progressOf(member, DAILY_REPORT_VIEW_ID).getStatus()).isEqualTo(MissionStatus.IN_PROGRESS);
+
+        // 특성화: ACHIEVEMENT 트랙이지만 DAILY_TRADE_COUNT(카이팅 장인)도 진행 중이면 매일 0으로 리셋
+        assertThat(progressOf(member, KITING_ACHIEVEMENT_ID).getCurrentValue()).isZero();
+        assertThat(progressOf(member, KITING_ACHIEVEMENT_ID).getStatus()).isEqualTo(MissionStatus.IN_PROGRESS);
+
+        // 트랙(SHORT_TERM) 미션 진행도는 영향 없음
+        assertThat(progressOf(member, SHORT_TERM_FIRST_ID).getCurrentValue()).isEqualTo(3);
+
+        // 특성화: 연속 출석 트래커(900)는 resetDailyMissions가 건드리지 않음 (출석 연쇄로 1 유지)
+        assertThat(progressOf(member, STREAK_TRACKER_ID).getCurrentValue()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("이미 완료된 카이팅 업적(904)은 일일 리셋 대상에서 제외된다")
+    void resetDailyMissions_완료된_카이팅업적은_리셋되지_않는다() {
+        // given
+        Member member = createMemberWithMissions();
+        MissionProgress kiting = progressOf(member, KITING_ACHIEVEMENT_ID);
+        kiting.setCurrentValue(50);
+        kiting.complete();
+        missionProgressRepository.flush();
+
+        // when
+        missionService.resetDailyMissions();
+
+        // then: IN_PROGRESS 상태의 DAILY_TRADE_COUNT만 리셋되므로 완료본은 보존
+        assertThat(progressOf(member, KITING_ACHIEVEMENT_ID).getCurrentValue()).isEqualTo(50);
+        assertThat(progressOf(member, KITING_ACHIEVEMENT_ID).getStatus()).isEqualTo(MissionStatus.COMPLETED);
+    }
+
+    // --- 3. processDailyHoldingUpdate ---
+
+    @Test
+    @DisplayName("보유 주식이 있는 회원의 진행 중 HOLDING_DAYS 미션만 +1 되고, 무보유 회원과 INACTIVE 미션은 변하지 않는다")
+    void processDailyHoldingUpdate_보유주식이_있으면_진행중_홀딩미션만_1증가한다() {
+        // given
+        Member holder = createMemberWithMissions();
+        giveStock(holder);
+        Member noStockMember = createMemberWithMissions();
+        missionProgressRepository.flush();
+
+        // when
+        missionService.processDailyHoldingUpdate();
+
+        // then: 진행 중(IN_PROGRESS)인 홀딩 미션(301, 401)만 +1
+        assertThat(progressOf(holder, SWING_HOLDING_2D_ID).getCurrentValue()).isEqualTo(1);
+        assertThat(progressOf(holder, SWING_HOLDING_2D_ID).getStatus()).isEqualTo(MissionStatus.IN_PROGRESS);
+        assertThat(progressOf(holder, LONG_TERM_HOLDING_7D_ID).getCurrentValue()).isEqualTo(1);
+
+        // INACTIVE 홀딩 미션(303, 403)은 대상 아님
+        assertThat(progressOf(holder, SWING_HOLDING_7D_ID).getCurrentValue()).isZero();
+        assertThat(progressOf(holder, SWING_HOLDING_7D_ID).getStatus()).isEqualTo(MissionStatus.INACTIVE);
+        assertThat(progressOf(holder, LONG_TERM_HOLDING_16D_ID).getCurrentValue()).isZero();
+
+        // 주식이 없는 회원은 변화 없음
+        assertThat(progressOf(noStockMember, SWING_HOLDING_2D_ID).getCurrentValue()).isZero();
+        assertThat(progressOf(noStockMember, LONG_TERM_HOLDING_7D_ID).getCurrentValue()).isZero();
+    }
+
+    @Test
+    @DisplayName("홀딩 일수가 목표에 도달하면 완료 전이·보상 지급·다음 미션 활성화·활동 점수 +10이 일어난다")
+    void processDailyHoldingUpdate_임계도달시_완료전이와_보상지급_다음미션_활성화() {
+        // given: 2일 홀딩 미션(301, 목표 2)이 있는 회원
+        Member holder = createMemberWithMissions();
+        giveStock(holder);
+        Account account = accountRepository.findByMemberAndIsDefaultTrue(holder).orElseThrow();
+        BigDecimal cashBefore = account.getCash();
+        missionProgressRepository.flush();
+
+        // when: 이틀치 스케줄 실행
+        missionService.processDailyHoldingUpdate();
+        missionService.processDailyHoldingUpdate();
+
+        // then: 301(목표 2)은 완료 전이
+        MissionProgress swingHolding = progressOf(holder, SWING_HOLDING_2D_ID);
+        assertThat(swingHolding.getCurrentValue()).isEqualTo(2);
+        assertThat(swingHolding.getStatus()).isEqualTo(MissionStatus.COMPLETED);
+
+        // 401(목표 7)은 계속 진행 중
+        assertThat(progressOf(holder, LONG_TERM_HOLDING_7D_ID).getCurrentValue()).isEqualTo(2);
+        assertThat(progressOf(holder, LONG_TERM_HOLDING_7D_ID).getStatus()).isEqualTo(MissionStatus.IN_PROGRESS);
+
+        // 다음 미션(302)이 INACTIVE -> IN_PROGRESS로 활성화
+        assertThat(progressOf(holder, SWING_PROFIT_5PCT_ID).getStatus()).isEqualTo(MissionStatus.IN_PROGRESS);
+        assertThat(progressOf(holder, SWING_PROFIT_5PCT_ID).getCurrentValue()).isZero();
+
+        // 보상(reward 21: 750,000원)이 기본 계좌에 지급
+        assertThat(account.getCash()).isEqualByComparingTo(cashBefore.add(BigDecimal.valueOf(750000)));
+
+        // 특성화: 미션 1건 완료 시 활동 점수 트래커(998, 초기값 1200) +10
+        assertThat(progressOf(holder, ACTIVITY_SCORE_TRACKER_ID).getCurrentValue()).isEqualTo(1210);
+    }
+
+    // --- 헬퍼 (슬라이스 자체 소유, 다른 테스트와 공유하지 않음) ---
+
+    private Member createMemberWithMissions() {
+        String email = "scheduler-" + UUID.randomUUID() + "@test.com";
+        Member member = memberRepository.save(Member.builder()
+                .name("scheduler-tester")
+                .email(email)
+                .password("password")
+                .provider(AuthProvider.LOCAL)
+                .build());
+        accountService.createDefaultAccountForMember(member);
+        missionService.initializeMissionsForNewMember(member);
+        missionProgressRepository.flush();
+        return member;
+    }
+
+    private void giveStock(Member member) {
+        Account account = accountRepository.findByMemberAndIsDefaultTrue(member).orElseThrow();
+        Stock stock = stockRepository.save(Stock.builder()
+                .code("TST" + UUID.randomUUID().toString().substring(0, 8))
+                .name("특성화테스트종목")
+                .marketType("KOSPI")
+                .build());
+        accountStockRepository.save(AccountStock.create(account, stock, 10, BigDecimal.valueOf(1000)));
+    }
+
+    private MissionProgress progressOf(Member member, long missionId) {
+        Mission mission = missionRepository.findById(missionId).orElseThrow();
+        return missionProgressRepository.findByMemberAndMission(member, mission).orElseThrow();
+    }
+}

--- a/src/test/java/grit/stockIt/domain/mission/service/MissionServiceIntegrationTest.java
+++ b/src/test/java/grit/stockIt/domain/mission/service/MissionServiceIntegrationTest.java
@@ -7,6 +7,7 @@ import grit.stockIt.domain.contest.repository.ContestRepository;
 import grit.stockIt.domain.member.entity.AuthProvider;
 import grit.stockIt.domain.member.entity.Member;
 import grit.stockIt.domain.member.repository.MemberRepository;
+import grit.stockIt.domain.mission.event.RankerAchievedEvent;
 import grit.stockIt.domain.mission.entity.Mission;
 import grit.stockIt.domain.mission.entity.MissionProgress;
 import grit.stockIt.domain.mission.enums.MissionStatus;
@@ -407,6 +408,17 @@ class MissionServiceIntegrationTest extends IntegrationTestSupport {
         missionProgressService.processRankerAchievement(List.of(memberId));
         assertThat(titleNames()).containsExactly("랭커");
         assertThat(defaultAccountCash()).isEqualByComparingTo(new BigDecimal("16000000"));
+    }
+
+    @Test
+    @DisplayName("8-1. RankerAchievedEvent 발행 경유: 동기 리스너 배선으로 랭커 미션이 처리된다")
+    void 랭커이벤트_발행경유_리스너배선_동작() {
+        // Risk 9(리스너 미배선 = 조용한 미션 미처리) 방어선 — 이벤트 배선이 끊기면 이 테스트가 red
+        txTemplate.executeWithoutResult(status ->
+                eventPublisher.publishEvent(new RankerAchievedEvent(List.of(memberId))));
+
+        assertThat(progress(909L).getStatus()).isEqualTo(MissionStatus.COMPLETED);
+        assertThat(titleNames()).containsExactly("랭커");
     }
 
     // --- 시나리오 9 ---

--- a/src/test/java/grit/stockIt/domain/mission/service/MissionServiceIntegrationTest.java
+++ b/src/test/java/grit/stockIt/domain/mission/service/MissionServiceIntegrationTest.java
@@ -1,0 +1,451 @@
+package grit.stockIt.domain.mission.service;
+
+import grit.stockIt.domain.account.entity.Account;
+import grit.stockIt.domain.account.repository.AccountRepository;
+import grit.stockIt.domain.contest.entity.Contest;
+import grit.stockIt.domain.contest.repository.ContestRepository;
+import grit.stockIt.domain.member.entity.AuthProvider;
+import grit.stockIt.domain.member.entity.Member;
+import grit.stockIt.domain.member.repository.MemberRepository;
+import grit.stockIt.domain.mission.entity.Mission;
+import grit.stockIt.domain.mission.entity.MissionProgress;
+import grit.stockIt.domain.mission.enums.MissionStatus;
+import grit.stockIt.domain.mission.repository.MissionProgressRepository;
+import grit.stockIt.domain.mission.repository.MissionRepository;
+import grit.stockIt.domain.order.entity.OrderMethod;
+import grit.stockIt.domain.order.event.TradeCompletionEvent;
+import grit.stockIt.domain.title.repository.MemberTitleRepository;
+import grit.stockIt.global.support.IntegrationTestSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import javax.sql.DataSource;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * MissionService 리팩토링 전 특성화(characterization) 테스트.
+ * 관찰된 "현재 동작"을 기대값으로 고정한다. 버그로 의심되는 동작도 그대로 단언한다.
+ *
+ * 전제(관찰 사실):
+ * - test 프로파일에는 spring.sql.init 설정이 없어 data.sql이 자동 실행되지 않으므로
+ *   테스트에서 직접 ResourceDatabasePopulator로 시드한다(ON CONFLICT upsert라 반복 실행에 안전).
+ * - data.sql에는 BUY_COUNT/BUY_AMOUNT/SELL_COUNT/SELL_AMOUNT 조건의 미션이 존재하지 않는다.
+ *   따라서 매수/매도 이벤트의 진행도 증가는 TRADE_COUNT(102, 201)와 DAILY_TRADE_COUNT(904)로 관찰한다.
+ */
+@DisplayName("MissionService 특성화 테스트 (리팩토링 전 현재 동작 고정)")
+class MissionServiceIntegrationTest extends IntegrationTestSupport {
+
+    private static final String STOCK_CODE = "CHRTEST"; // stock 테이블에 없는 코드 (checkSpecialAchievement에서 orElse(null) 허용)
+    private static final BigDecimal INITIAL_CASH = new BigDecimal("1000000");
+
+    @Autowired
+    private MissionService missionService;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private ContestRepository contestRepository;
+    @Autowired
+    private AccountRepository accountRepository;
+    @Autowired
+    private MissionRepository missionRepository;
+    @Autowired
+    private MissionProgressRepository missionProgressRepository;
+    @Autowired
+    private MemberTitleRepository memberTitleRepository;
+    @Autowired
+    private ApplicationEventPublisher eventPublisher;
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+    @Autowired
+    private DataSource dataSource;
+
+    private TransactionTemplate txTemplate;
+    private Long memberId;
+    private String memberEmail;
+    private Long defaultAccountId;
+    private Long contestId;
+
+    @BeforeEach
+    void setUp() {
+        txTemplate = new TransactionTemplate(transactionManager);
+
+        // data.sql 시드 (title/reward/mission upsert + next_mission 체인 연결)
+        new ResourceDatabasePopulator(new ClassPathResource("data.sql")).execute(dataSource);
+
+        String uniqueId = UUID.randomUUID().toString().substring(0, 8);
+        memberEmail = "mission-char-" + uniqueId + "@test.com";
+
+        txTemplate.executeWithoutResult(status -> {
+            Member member = memberRepository.save(Member.builder()
+                    .name("특성화" + uniqueId)
+                    .email(memberEmail)
+                    .provider(AuthProvider.LOCAL)
+                    .build());
+
+            Contest contest = contestRepository.save(Contest.builder()
+                    .contestName("특성화 대회 " + uniqueId)
+                    .startDate(LocalDateTime.now())
+                    .seedMoney(1000000L)
+                    .commissionRate(new BigDecimal("0.0000"))
+                    .isDefault(false)
+                    .build());
+
+            Account defaultAccount = accountRepository.save(Account.builder()
+                    .member(member)
+                    .contest(contest)
+                    .accountName("기본 계좌 " + uniqueId)
+                    .cash(INITIAL_CASH)
+                    .holdAmount(BigDecimal.ZERO)
+                    .isDefault(true)
+                    .build());
+
+            // 시나리오 1의 대상이자, 나머지 시나리오의 공용 픽스처 경로
+            missionService.initializeMissionsForNewMember(member);
+
+            memberId = member.getMemberId();
+            defaultAccountId = defaultAccount.getAccountId();
+            contestId = contest.getContestId();
+        });
+    }
+
+    // --- helpers ---
+
+    private MissionProgress progress(long missionId) {
+        Member member = memberRepository.findById(memberId).orElseThrow();
+        Mission mission = missionRepository.findById(missionId).orElseThrow();
+        return missionProgressRepository.findByMemberAndMission(member, mission).orElseThrow();
+    }
+
+    private void mutateProgress(long missionId, Consumer<MissionProgress> mutator) {
+        txTemplate.executeWithoutResult(status -> mutator.accept(progress(missionId)));
+    }
+
+    private BigDecimal defaultAccountCash() {
+        return accountRepository.findById(defaultAccountId).orElseThrow().getCash();
+    }
+
+    private List<String> titleNames() {
+        return txTemplate.execute(status -> {
+            Member member = memberRepository.findById(memberId).orElseThrow();
+            return memberTitleRepository.findAllByMember(member).stream()
+                    .map(mt -> mt.getTitle().getName())
+                    .collect(Collectors.toList());
+        });
+    }
+
+    private TradeCompletionEvent buyEvent(Long accountId, int quantity, String price) {
+        return new TradeCompletionEvent(memberId, accountId, STOCK_CODE,
+                OrderMethod.BUY, quantity, new BigDecimal(price));
+    }
+
+    private TradeCompletionEvent sellEvent(Long accountId, int quantity, String sellPrice, String buyAveragePrice) {
+        return new TradeCompletionEvent(memberId, accountId, STOCK_CODE,
+                OrderMethod.SELL, quantity, new BigDecimal(sellPrice),
+                null, null, 0, new BigDecimal(buyAveragePrice));
+    }
+
+    // --- 시나리오 1 ---
+
+    @Test
+    @DisplayName("1. initializeMissionsForNewMember: 트랙 첫 미션만 활성화되고 ACTIVITY_SCORE는 1200으로 시작한다")
+    void initializeMissionsForNewMember_트랙첫미션_활성화_및_활동점수_1200() {
+        // data.sql 기준 미션 29개(일일 4 + 업적 13 + 중급 6 + 고급 6) 전부 진행도 생성
+        Member member = memberRepository.findById(memberId).orElseThrow();
+        assertThat(missionProgressRepository.findByMemberWithMissionAndReward(member)).hasSize(29);
+
+        // 트랙별 첫 미션(201/301/401)만 IN_PROGRESS
+        for (long id : new long[] {201L, 301L, 401L}) {
+            assertThat(progress(id).getStatus()).as("mission %d", id).isEqualTo(MissionStatus.IN_PROGRESS);
+            assertThat(progress(id).getCurrentValue()).isZero();
+        }
+        // 나머지 트랙 미션은 INACTIVE
+        for (long id : new long[] {202L, 203L, 204L, 302L, 303L, 304L, 402L, 403L, 404L}) {
+            assertThat(progress(id).getStatus()).as("mission %d", id).isEqualTo(MissionStatus.INACTIVE);
+        }
+        // 일일 미션(101~104)과 업적 미션은 기본 IN_PROGRESS
+        for (long id : new long[] {101L, 102L, 103L, 104L, 900L, 901L, 902L, 909L, 998L, 999L}) {
+            assertThat(progress(id).getStatus()).as("mission %d", id).isEqualTo(MissionStatus.IN_PROGRESS);
+        }
+        // 특성화: 활동 점수 트래커(998)만 초기값 1200 (Silver 1 시작), 수익금 트래커(999)는 0
+        assertThat(progress(998L).getCurrentValue()).isEqualTo(1200);
+        assertThat(progress(999L).getCurrentValue()).isZero();
+    }
+
+    // --- 시나리오 2 ---
+
+    @Test
+    @DisplayName("2. BUY 이벤트: TRADE_COUNT 계열 진행도가 증가하고 일일 거래 미션(102)이 즉시 완료된다")
+    void updateMissionProgress_매수이벤트_TRADE_COUNT_증가() {
+        missionService.updateMissionProgress(buyEvent(defaultAccountId, 2, "10000"));
+
+        // 특성화: data.sql에는 BUY_COUNT/BUY_AMOUNT 미션이 없어 TRADE_COUNT 계열만 반응한다
+        assertThat(progress(201L).getCurrentValue()).isEqualTo(1);   // SHORT_TERM TRADE_COUNT
+        assertThat(progress(904L).getCurrentValue()).isEqualTo(1);   // ACHIEVEMENT DAILY_TRADE_COUNT
+
+        // 일일 거래 미션(102, goal 1) 즉시 완료 -> 보상 150,000원
+        assertThat(progress(102L).getStatus()).isEqualTo(MissionStatus.COMPLETED);
+        assertThat(progress(102L).getCurrentValue()).isEqualTo(1);
+        assertThat(defaultAccountCash()).isEqualByComparingTo(new BigDecimal("1150000"));
+
+        // 특성화: TOTAL_TRADE_AMOUNT(202)는 INACTIVE 상태라 조회 대상이 아니어서 미집계
+        assertThat(progress(202L).getStatus()).isEqualTo(MissionStatus.INACTIVE);
+        assertThat(progress(202L).getCurrentValue()).isZero();
+
+        // 미션 1건 완료 -> 활동 점수 +10, 시드 콜로니(901) 완료 카운트 반영
+        assertThat(progress(998L).getCurrentValue()).isEqualTo(1210);
+        assertThat(progress(901L).getCurrentValue()).isEqualTo(1);
+    }
+
+    // --- 시나리오 3 ---
+
+    @Test
+    @DisplayName("3. SELL 이벤트: HOLDING_DAYS 리셋 + 수익 실현 업적 + 누적 수익금(999) 반영")
+    void updateMissionProgress_매도이벤트_홀딩리셋_및_수익반영() {
+        mutateProgress(301L, p -> p.setCurrentValue(1)); // 홀딩 1일차 상태에서 매도
+
+        // 2주를 평단 10,000원에 사서 12,000원에 매도 -> 수익 4,000원
+        missionService.updateMissionProgress(sellEvent(defaultAccountId, 2, "12000", "10000"));
+
+        // 특성화: SELL 발생 시 HOLDING_DAYS는 무조건 0으로 리셋 (상태는 IN_PROGRESS 유지)
+        assertThat(progress(301L).getCurrentValue()).isZero();
+        assertThat(progress(301L).getStatus()).isEqualTo(MissionStatus.IN_PROGRESS);
+        assertThat(progress(401L).getCurrentValue()).isZero();
+
+        // SELL도 TRADE_COUNT 공통 조건에 걸린다
+        assertThat(progress(201L).getCurrentValue()).isEqualTo(1);
+        assertThat(progress(904L).getCurrentValue()).isEqualTo(1);
+        assertThat(progress(102L).getStatus()).isEqualTo(MissionStatus.COMPLETED);
+
+        // checkSpecialAchievement: 첫 수익 실현(902) 완료 + 칭호 '달콤한 첫입'
+        assertThat(progress(902L).getStatus()).isEqualTo(MissionStatus.COMPLETED);
+        assertThat(progress(902L).getCurrentValue()).isEqualTo(1);
+        assertThat(titleNames()).containsExactly("달콤한 첫입");
+
+        // updateSkillScore: 999 트래커에 순수익 4,000원 누적
+        assertThat(progress(999L).getCurrentValue()).isEqualTo(4000);
+
+        // 현금: 102 보상 150,000 + 902 보상 1,000,000
+        assertThat(defaultAccountCash()).isEqualByComparingTo(new BigDecimal("2150000"));
+
+        // 미션 2건 완료 -> 활동 점수 1200 + 20
+        assertThat(progress(998L).getCurrentValue()).isEqualTo(1220);
+        assertThat(progress(901L).getCurrentValue()).isEqualTo(2);
+    }
+
+    // --- 시나리오 4 ---
+
+    @Test
+    @DisplayName("4. 보조 계좌(isDefault=false) 이벤트는 미션 집계에서 완전히 제외된다")
+    void updateMissionProgress_보조계좌_이벤트_집계제외() {
+        Long auxAccountId = txTemplate.execute(status -> {
+            Member member = memberRepository.findById(memberId).orElseThrow();
+            Contest auxContest = contestRepository.save(Contest.builder()
+                    .contestName("보조 대회 " + UUID.randomUUID())
+                    .startDate(LocalDateTime.now())
+                    .seedMoney(1000000L)
+                    .commissionRate(new BigDecimal("0.0000"))
+                    .isDefault(false)
+                    .build());
+            Account aux = accountRepository.save(Account.builder()
+                    .member(member)
+                    .contest(auxContest)
+                    .accountName("보조 계좌")
+                    .cash(INITIAL_CASH)
+                    .holdAmount(BigDecimal.ZERO)
+                    .isDefault(false)
+                    .build());
+            return aux.getAccountId();
+        });
+
+        missionService.updateMissionProgress(buyEvent(auxAccountId, 2, "10000"));
+
+        // 아무것도 집계되지 않는다
+        assertThat(progress(201L).getCurrentValue()).isZero();
+        assertThat(progress(102L).getStatus()).isEqualTo(MissionStatus.IN_PROGRESS);
+        assertThat(progress(102L).getCurrentValue()).isZero();
+        assertThat(progress(904L).getCurrentValue()).isZero();
+        assertThat(progress(998L).getCurrentValue()).isEqualTo(1200);
+        assertThat(defaultAccountCash()).isEqualByComparingTo(INITIAL_CASH);
+    }
+
+    @Test
+    @DisplayName("4-1. AccountId가 null인 이벤트는 경고만 남기고 그대로 집계된다")
+    void updateMissionProgress_AccountId_null_이벤트_집계진행() {
+        // 특성화: 현재 동작, 버그 의심 — accountId가 null이면 기본 계좌 검증을 건너뛰고 집계를 진행한다
+        missionService.updateMissionProgress(buyEvent(null, 1, "10000"));
+
+        assertThat(progress(201L).getCurrentValue()).isEqualTo(1);
+        assertThat(progress(102L).getStatus()).isEqualTo(MissionStatus.COMPLETED);
+        assertThat(defaultAccountCash()).isEqualByComparingTo(new BigDecimal("1150000"));
+    }
+
+    // --- 시나리오 5 ---
+
+    @Test
+    @DisplayName("5. 목표 도달 시 완료 -> 보상 지급 -> 다음 미션 활성화 체인이 동작한다")
+    void checkMissionCompletion_완료시_보상지급_및_다음미션_활성화() {
+        mutateProgress(201L, p -> p.setCurrentValue(9)); // goal 10 직전
+
+        missionService.updateMissionProgress(buyEvent(defaultAccountId, 1, "10000"));
+
+        // 201 완료
+        assertThat(progress(201L).getStatus()).isEqualTo(MissionStatus.COMPLETED);
+        assertThat(progress(201L).getCurrentValue()).isEqualTo(10);
+
+        // 다음 미션 202가 INACTIVE -> IN_PROGRESS로 활성화
+        // 특성화: 활성화는 같은 이벤트 처리 루프 이후이므로 이번 이벤트는 202에 반영되지 않는다(currentValue 0)
+        assertThat(progress(202L).getStatus()).isEqualTo(MissionStatus.IN_PROGRESS);
+        assertThat(progress(202L).getCurrentValue()).isZero();
+
+        // 현금: 201 보상 300,000 + 일일 거래 미션(102) 보상 150,000
+        assertThat(progress(102L).getStatus()).isEqualTo(MissionStatus.COMPLETED);
+        assertThat(defaultAccountCash()).isEqualByComparingTo(new BigDecimal("1450000"));
+
+        // 완료 2건 -> 활동 점수 +20, 시드 콜로니 카운트 2
+        assertThat(progress(998L).getCurrentValue()).isEqualTo(1220);
+        assertThat(progress(901L).getCurrentValue()).isEqualTo(2);
+    }
+
+    // --- 시나리오 6 ---
+
+    @Test
+    @DisplayName("6. ADVANCED 미션 완료 시 트랙이 리셋되고 완료 기록 자체도 초기화된다")
+    void activateNextMission_고급미션완료_트랙리셋() {
+        // SHORT_TERM 트랙을 마지막 미션(204, DAILY_PROFIT_COUNT goal 3) 직전 상태로 세팅
+        mutateProgress(201L, MissionProgress::complete);
+        mutateProgress(202L, MissionProgress::complete);
+        mutateProgress(203L, MissionProgress::complete);
+        mutateProgress(204L, p -> {
+            p.activate();
+            p.setCurrentValue(2);
+        });
+        // 첫 수익 업적(902)은 미리 완료 처리하여 이번 시나리오에서 제외
+        mutateProgress(902L, p -> {
+            p.setCurrentValue(1);
+            p.complete();
+        });
+
+        // 익절 매도 -> 204 진행도 3 도달
+        missionService.updateMissionProgress(sellEvent(defaultAccountId, 1, "11000", "10000"));
+
+        // 특성화: 현재 동작, 버그 의심 — 204 완료 직후 resetMissionTrack이 트랙 전체(자기 자신 포함)를
+        // reset+deactivate 하므로 204의 COMPLETED 기록과 진행도가 소실된다(보상 현금은 이미 지급됨)
+        assertThat(progress(204L).getStatus()).isEqualTo(MissionStatus.INACTIVE);
+        assertThat(progress(204L).getCurrentValue()).isZero();
+
+        // 트랙 첫 미션(201)만 재활성화, 나머지는 INACTIVE + 0
+        assertThat(progress(201L).getStatus()).isEqualTo(MissionStatus.IN_PROGRESS);
+        assertThat(progress(201L).getCurrentValue()).isZero();
+        assertThat(progress(202L).getStatus()).isEqualTo(MissionStatus.INACTIVE);
+        assertThat(progress(202L).getCurrentValue()).isZero();
+        assertThat(progress(203L).getStatus()).isEqualTo(MissionStatus.INACTIVE);
+        assertThat(progress(203L).getCurrentValue()).isZero();
+
+        // 현금: 204 보상 2,000,000 + 일일 거래(102) 보상 150,000
+        assertThat(defaultAccountCash()).isEqualByComparingTo(new BigDecimal("3150000"));
+
+        // 매도 수익 1,000원은 999 트래커에 누적
+        assertThat(progress(999L).getCurrentValue()).isEqualTo(1000);
+    }
+
+    // --- 시나리오 7 ---
+
+    @Test
+    @DisplayName("7. 수익 매도 일회성 업적(달콤한 첫입)은 두 번째 수익에도 중복 지급되지 않는다")
+    void checkSpecialAchievement_첫수익업적_일회성() {
+        missionService.updateMissionProgress(sellEvent(defaultAccountId, 1, "11000", "10000"));
+        missionService.updateMissionProgress(sellEvent(defaultAccountId, 1, "11000", "10000"));
+
+        assertThat(progress(902L).getStatus()).isEqualTo(MissionStatus.COMPLETED);
+        assertThat(progress(902L).getCurrentValue()).isEqualTo(1);
+        // 칭호는 정확히 1회만 지급
+        assertThat(titleNames()).containsExactly("달콤한 첫입");
+        // 현금: 첫 이벤트에서만 102 보상 150,000 + 902 보상 1,000,000 (두 번째 이벤트는 보상 없음)
+        assertThat(defaultAccountCash()).isEqualByComparingTo(new BigDecimal("2150000"));
+
+        // 특성화: 업적은 일회성이지만 누적 수익금(999)은 매 매도마다 계속 누적된다 (1,000 x 2)
+        assertThat(progress(999L).getCurrentValue()).isEqualTo(2000);
+        assertThat(progress(904L).getCurrentValue()).isEqualTo(2);
+    }
+
+    // --- 시나리오 8 ---
+
+    @Test
+    @DisplayName("8. processRankerAchievement: Top10 진입 시 909 완료 + 랭커 칭호, 재호출 시 중복 지급 없음")
+    void processRankerAchievement_랭커업적_완료() {
+        // 존재하지 않는 회원 ID는 조용히 건너뛴다
+        missionService.processRankerAchievement(List.of(memberId, 999_999_999L));
+
+        assertThat(progress(909L).getStatus()).isEqualTo(MissionStatus.COMPLETED);
+        // 특성화: 목표치 10을 하드코딩으로 setCurrentValue(10) 처리
+        assertThat(progress(909L).getCurrentValue()).isEqualTo(10);
+        assertThat(titleNames()).containsExactly("랭커");
+        assertThat(defaultAccountCash()).isEqualByComparingTo(new BigDecimal("16000000"));
+        assertThat(progress(998L).getCurrentValue()).isEqualTo(1210);
+
+        // 재호출: 이미 완료된 회원은 보상/칭호 중복 지급 없음
+        missionService.processRankerAchievement(List.of(memberId));
+        assertThat(titleNames()).containsExactly("랭커");
+        assertThat(defaultAccountCash()).isEqualByComparingTo(new BigDecimal("16000000"));
+    }
+
+    // --- 시나리오 9 ---
+
+    @Test
+    @DisplayName("9-1. handleReportView: 리포트 3회 열람 시 일일 미션(103)이 완료된다")
+    void handleReportView_일일미션_진행_및_완료() {
+        missionService.handleReportView(memberEmail);
+        assertThat(progress(103L).getCurrentValue()).isEqualTo(1);
+        assertThat(progress(103L).getStatus()).isEqualTo(MissionStatus.IN_PROGRESS);
+
+        missionService.handleReportView(memberEmail);
+        missionService.handleReportView(memberEmail);
+        assertThat(progress(103L).getCurrentValue()).isEqualTo(3);
+        assertThat(progress(103L).getStatus()).isEqualTo(MissionStatus.COMPLETED);
+        assertThat(defaultAccountCash()).isEqualByComparingTo(new BigDecimal("1150000"));
+    }
+
+    @Test
+    @DisplayName("9-2. handlePortfolioAnalysis: 1회 분석으로 일일 미션(104) 완료, 재호출은 무시된다")
+    void handlePortfolioAnalysis_일일미션_완료_및_중복무시() {
+        missionService.handlePortfolioAnalysis(memberEmail);
+        assertThat(progress(104L).getCurrentValue()).isEqualTo(1);
+        assertThat(progress(104L).getStatus()).isEqualTo(MissionStatus.COMPLETED);
+        assertThat(defaultAccountCash()).isEqualByComparingTo(new BigDecimal("1150000"));
+
+        // 이미 완료된 미션은 진행/보상 없이 무시
+        missionService.handlePortfolioAnalysis(memberEmail);
+        assertThat(progress(104L).getCurrentValue()).isEqualTo(1);
+        assertThat(defaultAccountCash()).isEqualByComparingTo(new BigDecimal("1150000"));
+    }
+
+    // --- 시나리오 10 ---
+
+    @Test
+    @DisplayName("10. 동기 리스너 경유: 트랜잭션 안에서 발행한 TradeCompletionEvent가 커밋 후 진행도에 반영된다")
+    void 동기리스너_경유_이벤트발행_커밋후_반영() {
+        // MissionEventListener.handleTradeCompletionEvent는 @EventListener(동기)라
+        // publishEvent 시점에 발행자 트랜잭션에 참여하여 즉시 실행된다
+        txTemplate.executeWithoutResult(status ->
+                eventPublisher.publishEvent(buyEvent(defaultAccountId, 2, "10000")));
+
+        assertThat(progress(201L).getCurrentValue()).isEqualTo(1);
+        assertThat(progress(904L).getCurrentValue()).isEqualTo(1);
+        assertThat(progress(102L).getStatus()).isEqualTo(MissionStatus.COMPLETED);
+        assertThat(defaultAccountCash()).isEqualByComparingTo(new BigDecimal("1150000"));
+    }
+}

--- a/src/test/java/grit/stockIt/domain/mission/service/MissionServiceIntegrationTest.java
+++ b/src/test/java/grit/stockIt/domain/mission/service/MissionServiceIntegrationTest.java
@@ -45,6 +45,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  *   테스트에서 직접 ResourceDatabasePopulator로 시드한다(ON CONFLICT upsert라 반복 실행에 안전).
  * - data.sql에는 BUY_COUNT/BUY_AMOUNT/SELL_COUNT/SELL_AMOUNT 조건의 미션이 존재하지 않는다.
  *   따라서 매수/매도 이벤트의 진행도 증가는 TRADE_COUNT(102, 201)와 DAILY_TRADE_COUNT(904)로 관찰한다.
+ * - MissionCompletedEvent 발행 자체는 직접 단언하지 않는다: 수신부(MissionNotificationService)가
+ *   @Async라 flaky해지므로, 소비자 효과(901 완료 카운트, 998 활동 점수)로 간접 고정한다.
+ * - processRankerAchievement 예외 시 호출측(RankingService L113 catch) 흡수 시맨틱스는 검증하지 않는다:
+ *   스케줄러 직접 기동이 필요해 flaky하므로 문서화만 한다(승인된 계획 A-5의 명시 결정).
  */
 @DisplayName("MissionService 특성화 테스트 (리팩토링 전 현재 동작 고정)")
 class MissionServiceIntegrationTest extends IntegrationTestSupport {
@@ -447,5 +451,22 @@ class MissionServiceIntegrationTest extends IntegrationTestSupport {
         assertThat(progress(904L).getCurrentValue()).isEqualTo(1);
         assertThat(progress(102L).getStatus()).isEqualTo(MissionStatus.COMPLETED);
         assertThat(defaultAccountCash()).isEqualByComparingTo(new BigDecimal("1150000"));
+    }
+
+    @Test
+    @DisplayName("10-1. 동기 리스너 경유: 발행자 트랜잭션이 롤백되면 진행도도 함께 롤백된다")
+    void 동기리스너_경유_발행자_롤백시_진행도_미반영() {
+        // Risk 1(롤백 시맨틱스) 특성화: 동기 리스너는 발행자 tx에 REQUIRED로 참여하므로
+        // 발행자가 롤백하면 리스너가 만든 진행도 변경도 함께 사라져야 한다
+        int before = progress(201L).getCurrentValue();
+
+        txTemplate.executeWithoutResult(status -> {
+            eventPublisher.publishEvent(buyEvent(defaultAccountId, 2, "10000"));
+            status.setRollbackOnly();
+        });
+
+        assertThat(progress(201L).getCurrentValue()).isEqualTo(before);
+        assertThat(progress(102L).getStatus()).isEqualTo(MissionStatus.IN_PROGRESS);
+        assertThat(defaultAccountCash()).isEqualByComparingTo(INITIAL_CASH);
     }
 }

--- a/src/test/java/grit/stockIt/domain/mission/service/MissionServiceIntegrationTest.java
+++ b/src/test/java/grit/stockIt/domain/mission/service/MissionServiceIntegrationTest.java
@@ -59,6 +59,8 @@ class MissionServiceIntegrationTest extends IntegrationTestSupport {
     @Autowired
     private MissionService missionService;
     @Autowired
+    private MissionProgressService missionProgressService;
+    @Autowired
     private MemberRepository memberRepository;
     @Autowired
     private ContestRepository contestRepository;
@@ -194,7 +196,7 @@ class MissionServiceIntegrationTest extends IntegrationTestSupport {
     @Test
     @DisplayName("2. BUY 이벤트: TRADE_COUNT 계열 진행도가 증가하고 일일 거래 미션(102)이 즉시 완료된다")
     void updateMissionProgress_매수이벤트_TRADE_COUNT_증가() {
-        missionService.updateMissionProgress(buyEvent(defaultAccountId, 2, "10000"));
+        missionProgressService.updateMissionProgress(buyEvent(defaultAccountId, 2, "10000"));
 
         // 특성화: data.sql에는 BUY_COUNT/BUY_AMOUNT 미션이 없어 TRADE_COUNT 계열만 반응한다
         assertThat(progress(201L).getCurrentValue()).isEqualTo(1);   // SHORT_TERM TRADE_COUNT
@@ -222,7 +224,7 @@ class MissionServiceIntegrationTest extends IntegrationTestSupport {
         mutateProgress(301L, p -> p.setCurrentValue(1)); // 홀딩 1일차 상태에서 매도
 
         // 2주를 평단 10,000원에 사서 12,000원에 매도 -> 수익 4,000원
-        missionService.updateMissionProgress(sellEvent(defaultAccountId, 2, "12000", "10000"));
+        missionProgressService.updateMissionProgress(sellEvent(defaultAccountId, 2, "12000", "10000"));
 
         // 특성화: SELL 발생 시 HOLDING_DAYS는 무조건 0으로 리셋 (상태는 IN_PROGRESS 유지)
         assertThat(progress(301L).getCurrentValue()).isZero();
@@ -275,7 +277,7 @@ class MissionServiceIntegrationTest extends IntegrationTestSupport {
             return aux.getAccountId();
         });
 
-        missionService.updateMissionProgress(buyEvent(auxAccountId, 2, "10000"));
+        missionProgressService.updateMissionProgress(buyEvent(auxAccountId, 2, "10000"));
 
         // 아무것도 집계되지 않는다
         assertThat(progress(201L).getCurrentValue()).isZero();
@@ -290,7 +292,7 @@ class MissionServiceIntegrationTest extends IntegrationTestSupport {
     @DisplayName("4-1. AccountId가 null인 이벤트는 경고만 남기고 그대로 집계된다")
     void updateMissionProgress_AccountId_null_이벤트_집계진행() {
         // 특성화: 현재 동작, 버그 의심 — accountId가 null이면 기본 계좌 검증을 건너뛰고 집계를 진행한다
-        missionService.updateMissionProgress(buyEvent(null, 1, "10000"));
+        missionProgressService.updateMissionProgress(buyEvent(null, 1, "10000"));
 
         assertThat(progress(201L).getCurrentValue()).isEqualTo(1);
         assertThat(progress(102L).getStatus()).isEqualTo(MissionStatus.COMPLETED);
@@ -304,7 +306,7 @@ class MissionServiceIntegrationTest extends IntegrationTestSupport {
     void checkMissionCompletion_완료시_보상지급_및_다음미션_활성화() {
         mutateProgress(201L, p -> p.setCurrentValue(9)); // goal 10 직전
 
-        missionService.updateMissionProgress(buyEvent(defaultAccountId, 1, "10000"));
+        missionProgressService.updateMissionProgress(buyEvent(defaultAccountId, 1, "10000"));
 
         // 201 완료
         assertThat(progress(201L).getStatus()).isEqualTo(MissionStatus.COMPLETED);
@@ -344,7 +346,7 @@ class MissionServiceIntegrationTest extends IntegrationTestSupport {
         });
 
         // 익절 매도 -> 204 진행도 3 도달
-        missionService.updateMissionProgress(sellEvent(defaultAccountId, 1, "11000", "10000"));
+        missionProgressService.updateMissionProgress(sellEvent(defaultAccountId, 1, "11000", "10000"));
 
         // 특성화: 현재 동작, 버그 의심 — 204 완료 직후 resetMissionTrack이 트랙 전체(자기 자신 포함)를
         // reset+deactivate 하므로 204의 COMPLETED 기록과 진행도가 소실된다(보상 현금은 이미 지급됨)
@@ -371,8 +373,8 @@ class MissionServiceIntegrationTest extends IntegrationTestSupport {
     @Test
     @DisplayName("7. 수익 매도 일회성 업적(달콤한 첫입)은 두 번째 수익에도 중복 지급되지 않는다")
     void checkSpecialAchievement_첫수익업적_일회성() {
-        missionService.updateMissionProgress(sellEvent(defaultAccountId, 1, "11000", "10000"));
-        missionService.updateMissionProgress(sellEvent(defaultAccountId, 1, "11000", "10000"));
+        missionProgressService.updateMissionProgress(sellEvent(defaultAccountId, 1, "11000", "10000"));
+        missionProgressService.updateMissionProgress(sellEvent(defaultAccountId, 1, "11000", "10000"));
 
         assertThat(progress(902L).getStatus()).isEqualTo(MissionStatus.COMPLETED);
         assertThat(progress(902L).getCurrentValue()).isEqualTo(1);
@@ -392,7 +394,7 @@ class MissionServiceIntegrationTest extends IntegrationTestSupport {
     @DisplayName("8. processRankerAchievement: Top10 진입 시 909 완료 + 랭커 칭호, 재호출 시 중복 지급 없음")
     void processRankerAchievement_랭커업적_완료() {
         // 존재하지 않는 회원 ID는 조용히 건너뛴다
-        missionService.processRankerAchievement(List.of(memberId, 999_999_999L));
+        missionProgressService.processRankerAchievement(List.of(memberId, 999_999_999L));
 
         assertThat(progress(909L).getStatus()).isEqualTo(MissionStatus.COMPLETED);
         // 특성화: 목표치 10을 하드코딩으로 setCurrentValue(10) 처리
@@ -402,7 +404,7 @@ class MissionServiceIntegrationTest extends IntegrationTestSupport {
         assertThat(progress(998L).getCurrentValue()).isEqualTo(1210);
 
         // 재호출: 이미 완료된 회원은 보상/칭호 중복 지급 없음
-        missionService.processRankerAchievement(List.of(memberId));
+        missionProgressService.processRankerAchievement(List.of(memberId));
         assertThat(titleNames()).containsExactly("랭커");
         assertThat(defaultAccountCash()).isEqualByComparingTo(new BigDecimal("16000000"));
     }

--- a/src/test/java/grit/stockIt/domain/mission/service/MissionTrackPolicyTest.java
+++ b/src/test/java/grit/stockIt/domain/mission/service/MissionTrackPolicyTest.java
@@ -1,0 +1,28 @@
+package grit.stockIt.domain.mission.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * [B-1 단위 특성화] MissionTrackPolicy — data.sql 시드 기준 트랙 첫 미션 ID(201/301/401) 판정 고정.
+ */
+@DisplayName("MissionTrackPolicy 단위 특성화 테스트")
+class MissionTrackPolicyTest {
+
+    private final MissionTrackPolicy policy = new MissionTrackPolicy();
+
+    @ParameterizedTest
+    @ValueSource(longs = {201L, 301L, 401L})
+    void 트랙_첫_미션_ID는_201_301_401이다(long missionId) {
+        assertThat(policy.isFirstMissionInTrack(missionId)).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {0L, 101L, 200L, 202L, 300L, 302L, 400L, 402L, 904L, 998L})
+    void 그_외_ID는_트랙_첫_미션이_아니다(long missionId) {
+        assertThat(policy.isFirstMissionInTrack(missionId)).isFalse();
+    }
+}

--- a/src/test/java/grit/stockIt/global/support/IntegrationTestSupport.java
+++ b/src/test/java/grit/stockIt/global/support/IntegrationTestSupport.java
@@ -7,32 +7,38 @@ import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 /**
  * Testcontainers 기반 통합 테스트 공용 베이스 클래스.
  * PostgreSQL/Redis 컨테이너를 자동으로 띄우므로 로컬 DB 없이 어디서든(CI 포함) 실행 가능하다.
  * DB가 필요한 @SpringBootTest 는 이 클래스를 상속한다.
+ *
+ * 컨테이너는 싱글턴 패턴으로 JVM당 1회만 기동한다. @Testcontainers/@Container 확장은
+ * 클래스마다 컨테이너를 정지·재시작해 새 포트를 할당하는데, 캐시된 Spring 컨텍스트는
+ * 최초 포트를 유지하므로 컨텍스트를 공유하는 두 번째 테스트 클래스부터 연결이 깨진다.
+ * (withReuse(true)는 ~/.testcontainers.properties의 testcontainers.reuse.enable=true와
+ * 결합해 gradle 실행 간 컨테이너 재사용까지 허용한다.)
  */
 @SpringBootTest
 @ActiveProfiles("test")
-@Testcontainers
 @TestPropertySource(properties = "spring.task.scheduling.enabled=false")
 public abstract class IntegrationTestSupport {
 
-    @Container
     static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>(DockerImageName.parse("postgres:15"))
             .withDatabaseName("test_database")
             .withUsername("test_user")
             .withPassword("test_password")
             .withReuse(true);
 
-    @Container
     static final GenericContainer<?> REDIS = new GenericContainer<>(DockerImageName.parse("redis:7"))
             .withExposedPorts(6379)
             .withReuse(true);
+
+    static {
+        POSTGRES.start();
+        REDIS.start();
+    }
 
     @DynamicPropertySource
     static void configureContainers(DynamicPropertyRegistry registry) {


### PR DESCRIPTION
### 🚀 Summary

테스트 0개였던 1,075줄짜리 God Class `MissionService`를 **특성화 테스트로 현재 동작을 동결한 뒤** 책임별 6개 클래스로 분해하고, 타 도메인(auth/member/ranking)이 mission을 직접 주입하던 강결합을 도메인 이벤트로 끊었습니다. **관찰 가능한 동작은 변경 없음**(의도된 동작 변경 0건), mission 라인 커버리지 0% → **76.7%**.

---

### 📝 변경 사항

**Phase A — 안전망 (프로덕션 무수정)**
- mission 도메인 특성화 테스트 신규: 통합 4클래스 + 단위 3클래스 (총 134 테스트). 현재 동작을 버그 의심 지점까지 그대로 고정
- `IntegrationTestSupport` 싱글턴 컨테이너 패턴 전환 — 다중 통합테스트 클래스 동시 실행 시 컨테이너 생명주기 충돌로 무작위 실패하던 문제 근본 수정 (전체 스위트 19분 → 37초)

**Phase B — `MissionService` 6단계 분해 (1,075 → 199줄)**
- `MissionConditionEvaluator` / `MissionProgressCalculator` / `MissionTrackPolicy` — 순수 계산·정책 로직 추출(단위 테스트 가능)
- `MissionQueryService`(readOnly) / `MissionRewardService`(sink) / `MissionProgressService` / `MissionBatchService` 책임 분리
- 호출 그래프 역산으로 귀속해 순환 의존 없는 DAG 구성 (`MissionService`는 회원 액션 전담으로 잔류)

**Phase D — 도메인 간 결합 제거 (이벤트 전환)**
- 가입→미션 초기화: `MemberRegisteredEvent` 동기 발행 (`KakaoAuthService`/`LocalMemberService`의 mission 주입 제거)
- 랭커 업적: `RankerAchievedEvent` 동기 발행 (`RankingService`의 mission 주입은 조회용 `MissionQueryService` 1개만 잔존)
- **동기 리스너 유지** — 기존 트랜잭션·롤백 시맨틱스 보존

**문서**
- `docs/mission-refactor-changes.md` — 의도된 동작 변경 목록(빈 목록) + 발견한 버그 의심 10건 판정 요청 보고서

---

### 🏷️ 변경 유형

- [ ] ✨ 기능 (feat)
- [ ] 🐛 버그 수정 (fix)
- [x] ♻️ 리팩토링 (refactor)
- [x] 📑 문서 (docs)
- [ ] 🧭 환경설정 / 인프라 (chore)
- [ ] ⚠️ Breaking change (기존 동작/API 변경) — 해당 없음 (동작·API 계약 무변경)

---

### ✅ 테스트 / 검증 방법

- `./gradlew clean build` — 전체 스위트 **160 통과 / 0 실패** (skip 3 = 기존 외부 연동 수동 테스트)
- `./gradlew jacocoTestReport` — mission 라인 커버리지 **76.7%** (553/721, 기준선 70.5%에서 상승)
- 동작 보존 증빙:
  - 특성화 테스트가 분해·이벤트 전환 전후 **단언 무수정**으로 통과 (구조만 변경, 동작 불변)
  - 이동한 메서드 본문 원본과 정규화 대조 → IDENTICAL
  - 가입 롤백 전파 테스트가 이벤트 전환 후에도 무수정 green (트랜잭션 시맨틱스 보존)
- 정합성: Checkstyle 0경고, ArchUnit 통과, `suppressions.xml`·`archunit_store`·`data.sql`·DTO 필드 **diff 0**

---

### 🖼️ 실행 결과 / 스크린샷

해당 없음 (내부 구조 리팩토링, UI·API 응답 변화 없음)

---

### 🔀 배포 / 마이그레이션 노트

없음 (DB 스키마·Flyway·환경변수 변경 없음)

---

### ☑️ 체크리스트

- [x] 셀프 리뷰를 완료했습니다
- [x] 코드 컨벤션(네이밍 / DTO / REST 경로)을 따랐습니다 — `{Domain}{역할}Service`, 파일당 최상위 클래스 1개
- [x] 테스트를 추가/수정했고 통과합니다
- [x] 필요한 문서(README / AGENTS / docs)를 갱신했습니다 — `docs/mission-refactor-changes.md`
- [x] 시크릿·민감 정보가 커밋에 포함되지 않았습니다

---

### 리뷰어 주목 포인트

1. **`docs/mission-refactor-changes.md`의 버그 의심 10건** — 이번 PR에서 **수정하지 않고** 판정 대기로 남겼습니다(동작 변경이라 별도 PR 대상). 특히 (g) 이메일 로컬파트 20자 초과 시 가입 실패, (f) 파산 기준 문서-코드 불일치는 실사용자 영향 가능성이 있어 우선 검토 요청드립니다.
2. **버그로 보이는 동작도 특성화 테스트가 그대로 단언**합니다 — "왜 이 이상한 동작을 테스트가 기대하지?" 싶은 부분은 의도된 동작 고정이며, 주석에 `특성화: 버그 의심`으로 표기해뒀습니다.

> 참고: 실행 검증 산출물(`build/qa-artifacts/`)은 gitignore 대상이라 PR에 포함되지 않습니다.

---

### 🎲 관련 이슈

close #
