### PR TITLE
fix: 미션 거래 이벤트를 AFTER_COMMIT + @Async로 분리해 체결 롤백 방지

### DIFF
--- a/src/main/java/grit/stockIt/domain/matching/service/LimitOrderExecutionService.java
+++ b/src/main/java/grit/stockIt/domain/matching/service/LimitOrderExecutionService.java
@@ -201,25 +201,21 @@ public class LimitOrderExecutionService {
                 if (order.getRemainingQuantity() <= 0) {
                     finalizeFilledOrder(order, account);
 
-                    try {
-                        TradeCompletionEvent missionEvent = new TradeCompletionEvent(
-                                account.getMember().getMemberId(),
-                                account.getAccountId(),
-                                order.getStock().getCode(),
-                                order.getOrderMethod(),
-                                order.getQuantity(),         // 총 주문 수량
-                                event.price(),               // 체결 가격 (매도 단가)
-                                null,
-                                null,
-                                0,
-                                currentAvgPrice
-                        );
-                        eventPublisher.publishEvent(missionEvent);
-                        log.info("미션 시스템 이벤트 발행 (주문 완료 기준): MemberId={}", missionEvent.getMemberId());
-
-                    } catch (Exception e) {
-                        log.error("미션 이벤트 발행 실패: orderId={}", order.getOrderId(), e);
-                    }
+                    TradeCompletionEvent missionEvent = new TradeCompletionEvent(
+                            account.getMember().getMemberId(),
+                            account.getAccountId(),
+                            order.getStock().getCode(),
+                            order.getOrderMethod(),
+                            order.getQuantity(),         // 총 주문 수량
+                            event.price(),               // 체결 가격 (매도 단가)
+                            null,
+                            null,
+                            0,
+                            currentAvgPrice
+                    );
+                    // 미션 리스너는 AFTER_COMMIT이라 발행은 커밋 후 처리를 등록만 한다(체결에 영향 없음).
+                    eventPublisher.publishEvent(missionEvent);
+                    log.info("미션 시스템 이벤트 발행 (주문 완료 기준): MemberId={}", missionEvent.getMemberId());
                 }
             } catch (IllegalArgumentException ex) {
                 log.error("주문 체결 처리 중 오류 발생. orderId={} fillQuantity={}", orderId, actualFillQuantity, ex);

--- a/src/main/java/grit/stockIt/domain/mission/service/MissionEventListener.java
+++ b/src/main/java/grit/stockIt/domain/mission/service/MissionEventListener.java
@@ -10,6 +10,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import org.springframework.scheduling.annotation.Async;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Slf4j
 @Component
@@ -21,11 +23,17 @@ public class MissionEventListener {
 
     /**
      * 주식 '체결 완료' 이벤트를 수신합니다.
+     * 체결 트랜잭션 커밋 후(AFTER_COMMIT) 별도 스레드(@Async)에서 실행하여, 미션 로직의 실패가
+     * 체결 트랜잭션을 롤백시키지 못하게 한다. 단, 커밋 이후 실행이라 실패 시 갱신은 유실될 수 있다.
      */
-    @EventListener
-    public void handleTradeCompletionEvent(TradeCompletionEvent event) { // 2. [수정] 메서드명과 파라미터 변경
-        // 거래 진행도 로직은 MissionProgressService에 위임합니다.
-        missionProgressService.updateMissionProgress(event);
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleTradeCompletionEvent(TradeCompletionEvent event) {
+        try {
+            missionProgressService.updateMissionProgress(event);
+        } catch (Exception e) {
+            log.error("거래 미션 진행도 갱신 실패: memberId={}", event.getMemberId(), e);
+        }
     }
 
     /**

--- a/src/test/java/grit/stockIt/domain/mission/service/MissionServiceIntegrationTest.java
+++ b/src/test/java/grit/stockIt/domain/mission/service/MissionServiceIntegrationTest.java
@@ -36,6 +36,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
  * MissionService 리팩토링 전 특성화(characterization) 테스트.
@@ -143,6 +144,26 @@ class MissionServiceIntegrationTest extends IntegrationTestSupport {
 
     private BigDecimal defaultAccountCash() {
         return accountRepository.findById(defaultAccountId).orElseThrow().getCash();
+    }
+
+    /** AFTER_COMMIT + @Async 리스너는 별도 스레드에서 실행되므로 기대값 도달까지 폴링한다(최대 5초). */
+    private void awaitProgress(long missionId, int expected) {
+        long deadline = System.currentTimeMillis() + 5000;
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                if (progress(missionId).getCurrentValue() == expected) {
+                    return;
+                }
+            } catch (RuntimeException ignored) {
+                // 진행도 행이 아직 커밋되지 않았을 수 있음 — 재시도
+            }
+            try {
+                Thread.sleep(50);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
     }
 
     private List<String> titleNames() {
@@ -454,12 +475,14 @@ class MissionServiceIntegrationTest extends IntegrationTestSupport {
     // --- 시나리오 10 ---
 
     @Test
-    @DisplayName("10. 동기 리스너 경유: 트랜잭션 안에서 발행한 TradeCompletionEvent가 커밋 후 진행도에 반영된다")
-    void 동기리스너_경유_이벤트발행_커밋후_반영() {
-        // MissionEventListener.handleTradeCompletionEvent는 @EventListener(동기)라
-        // publishEvent 시점에 발행자 트랜잭션에 참여하여 즉시 실행된다
+    @DisplayName("10. 비동기 리스너 경유: 커밋된 TradeCompletionEvent가 커밋 후 진행도에 반영된다")
+    void 비동기리스너_경유_이벤트발행_커밋후_반영() {
+        // handleTradeCompletionEvent는 @Async + @TransactionalEventListener(AFTER_COMMIT)라
+        // 발행자 트랜잭션 커밋 후 별도 스레드에서 실행된다 → 반영을 폴링으로 대기한다
         txTemplate.executeWithoutResult(status ->
                 eventPublisher.publishEvent(buyEvent(defaultAccountId, 2, "10000")));
+
+        awaitProgress(201L, 1);
 
         assertThat(progress(201L).getCurrentValue()).isEqualTo(1);
         assertThat(progress(904L).getCurrentValue()).isEqualTo(1);
@@ -468,10 +491,10 @@ class MissionServiceIntegrationTest extends IntegrationTestSupport {
     }
 
     @Test
-    @DisplayName("10-1. 동기 리스너 경유: 발행자 트랜잭션이 롤백되면 진행도도 함께 롤백된다")
-    void 동기리스너_경유_발행자_롤백시_진행도_미반영() {
-        // Risk 1(롤백 시맨틱스) 특성화: 동기 리스너는 발행자 tx에 REQUIRED로 참여하므로
-        // 발행자가 롤백하면 리스너가 만든 진행도 변경도 함께 사라져야 한다
+    @DisplayName("10-1. 비동기 리스너 경유: 발행자 트랜잭션이 롤백되면 미션 진행도가 반영되지 않는다")
+    void 비동기리스너_경유_발행자_롤백시_진행도_미반영() {
+        // AFTER_COMMIT 리스너는 발행자 트랜잭션이 롤백되면 아예 트리거되지 않는다.
+        // → 미션 로직이 실행되지 않아 진행도/현금이 그대로 유지된다(롤백된 거래에 보상 미지급).
         int before = progress(201L).getCurrentValue();
 
         txTemplate.executeWithoutResult(status -> {
@@ -482,5 +505,19 @@ class MissionServiceIntegrationTest extends IntegrationTestSupport {
         assertThat(progress(201L).getCurrentValue()).isEqualTo(before);
         assertThat(progress(102L).getStatus()).isEqualTo(MissionStatus.IN_PROGRESS);
         assertThat(defaultAccountCash()).isEqualByComparingTo(INITIAL_CASH);
+    }
+
+    @Test
+    @DisplayName("10-2. 미션 로직이 예외를 던져도 발행자(체결) 트랜잭션은 정상 커밋된다")
+    void 미션예외_발행자트랜잭션_정상커밋() {
+        // 존재하지 않는 memberId → updateMissionProgress가 예외를 던지지만, AFTER_COMMIT + @Async라
+        // 그 예외가 별도 스레드에서 발생해 발행자 트랜잭션 커밋에 영향을 주지 않아야 한다.
+        Long ghostMemberId = 999_999_999L;
+        TradeCompletionEvent poison = new TradeCompletionEvent(
+                ghostMemberId, defaultAccountId, STOCK_CODE, OrderMethod.BUY, 1, new BigDecimal("10000"));
+
+        assertThatCode(() ->
+                txTemplate.executeWithoutResult(status -> eventPublisher.publishEvent(poison))
+        ).doesNotThrowAnyException();
     }
 }


### PR DESCRIPTION
### 🚀 Summary

체결 트랜잭션 안에서 동기 리스너로 미션 진행도를 갱신하던 구조는, 미션 로직 예외가
트랜잭션을 rollback-only로 오염시켜 실제 주식 체결까지 롤백시켰다. 리스너를
@Async + @TransactionalEventListener(AFTER_COMMIT)로 전환해 미션 처리를 체결
트랜잭션에서 분리한다.

---

### 📝 변경 사항

- `MissionEventListener.handleTradeCompletionEvent`를 `@EventListener`(동기·동일 트랜잭션)에서 `@Async` + `@TransactionalEventListener(AFTER_COMMIT)`로 전환 — 커밋 후 별도 스레드/트랜잭션에서 실행되어 미션 실패가 체결을 롤백시키지 못하고, 롤백된 거래에 보상이 반영되는 유령 보상·미커밋 가시성 레이스도 차단
- `LimitOrderExecutionService` 발행부의 오해 소지 있던 try-catch(`"미션 이벤트 발행 실패"`) 제거 — AFTER_COMMIT이라 발행은 커밋 후 처리를 등록만 함
- 특성화 테스트 갱신: 10번(비동기 폴링), 10-1번(롤백 시 리스너 미트리거), 10-2번 신규(미션 예외에도 발행자 트랜잭션이 정상 커밋됨을 검증)

---

### 🏷️ 변경 유형

- [ ] ✨ 기능 (feat)
- [x] 🐛 버그 수정 (fix)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] 📑 문서 (docs)
- [ ] 🧭 환경설정 / 인프라 (chore)
- [ ] ⚠️ Breaking change (기존 동작/API 변경)

---

### ✅ 테스트 / 검증 방법

- `MissionServiceIntegrationTest`(10/10-1/10-2 포함) 통과
- 미션 패키지 전체 + `LimitOrderMatchingServiceConcurrencyTest` 통과
- `./gradlew build`(전체 테스트 + Checkstyle + ArchUnit) BUILD SUCCESSFUL

---

### 🖼️ 실행 결과 / 스크린샷

---

### 🔀 배포 / 마이그레이션 노트

없음

---

### ☑️ 체크리스트

- [x] 셀프 리뷰를 완료했습니다
- [x] 코드 컨벤션(네이밍 / DTO / REST 경로)을 따랐습니다
- [x] 테스트를 추가/수정했고 통과합니다
- [ ] 필요한 문서(README / AGENTS / docs)를 갱신했습니다
- [x] 시크릿·민감 정보가 커밋에 포함되지 않았습니다

---

### 🔎 리뷰 포인트 (후속 검토)

- 커밋 이후 실행이라 미션 로직 실패 시 갱신이 유실될 수 있음 — 재시도/아웃박스 필요성은 이슈 #205 To Do에 별도 기록

---

### 🎲 관련 이슈

close #205
