### PR TITLE
refactor: OrderService 테스트 가능성 리팩토링 (특성화 안전망 + 4단계 책임 분해)

### DIFF
--- a/docs/order-refactor-changes.md
+++ b/docs/order-refactor-changes.md
@@ -1,0 +1,55 @@
+# order 도메인(OrderService) 리팩토링 — 의도된 동작 변경 목록 및 버그 판정 요청
+
+브랜치: `refactor/order-testability` (develop 6500db5 기반)
+근거 계획: ralplan 합의 계획 `pending-approval.md` (deep-interview 스펙 `order-testability-refactor` 기반), Architect CLEAR/APPROVE + Critic OKAY
+
+## 1. 의도된 동작 변경 목록 (AC)
+
+> 원칙: 리팩토링 전후 관찰 가능한 동작(API 응답·DB 상태·오더북 상태·발행 이벤트·예외)은 동일하다.
+> 명백한 버그는 사용자 판정 후에만 별도 커밋으로 수정한다.
+
+| # | 지점 | 사용자 승인 근거 | 커밋 해시 |
+|---|------|-----------------|----------|
+| — | (없음) | 승인된 버그 수정 0건 — 프로덕션 관찰 동작 변경 없음 | — |
+
+### 참고: 순수 구조 변경(관찰 동작 아님)
+
+| 지점 | 내용 | 성격 |
+|------|------|------|
+| `OrderService` 373→221줄 | God Class를 C1~C4 + 슬림 오케스트레이터로 분해 | 책임 분리(SRP), public API·트랜잭션 시맨틱스 보존 |
+| `OrderBookRegistrationService.registerAfterCommit` | `isActualTransactionActive()` false 시 warn-log 추가(신규 라인) | 방어 관측성. 보존 흐름에선 항상 활성이라 미발화 → 관찰 동작 중립 |
+| `OrderHoldService.applyBuyHold` | 인라인 `OrderHold.create/save` 2줄을 승격 메서드로 추출 | save→OrderHold FK 순서 보존, 최종 DB 상태 동일 |
+| 테스트 하네스(spy 격리) | 특성화 테스트의 @SpyBean 컨텍스트 격리 강화 | 테스트 신뢰성, 프로덕션 무관 |
+
+## 2. 버그 의심 지점 — 사용자 판정 요청
+
+> 아래 6건은 전부 **현재 동작 그대로 특성화 테스트로 고정**(수정 안 함). 수정 승인 시 해당 특성화를 기대값 갱신과 함께 별도 커밋으로 처리한다.
+> 리팩토링 후 메서드가 C1~C4로 이동했으나 **본문은 원본과 정규화 대조 IDENTICAL**(applyBuyHold 승격 제외)이라 동작은 develop과 동일하다.
+
+| # | 지점(현 소유 클래스) | 현재 동작 | 왜 의심스러운가 | 고정한 시나리오 |
+|---|------|----------|----------------|--------------|
+| a | `OrderService.createMarketOrder` + `OrderBookRegistrationService`(선구독 preSubscribe / afterCommit registerLimitOrder) | 시장가 매수/매도 시 `registerLimitOrder`를 저장 전 1회(선구독) + 커밋 후 afterCommit 1회 = **총 2회** 호출. 지정가엔 없는 선등록 | 이중 등록 비대칭. 롤백(KIS 실패·현금부족)해도 선구독 잔존(unregister 없음) | 8·13(times 2), 14·28(롤백 후 잔존) |
+| b | `OrderHoldService.releaseBuyHold` | 매수 주문 취소 시 `OrderHold`가 존재할 때만(`ifPresent`) 홀딩 감소 | `OrderHold` 유실 시 `Account.holdAmount`가 영구 잔류(현금 잠김) | 22 |
+| c | `OrderPricingService.calculateMarketHoldAmount` | KIS 현재가 폴백의 모든 예외를 `BadRequestException('최근 체결가 정보를 찾을 수 없습니다')`로 뭉뚱그림 | 타임아웃/네트워크/무효가를 400으로 은폐(원인 소실), 5xx여야 할 케이스 혼동 | 10 |
+| d | `OrderService.createMarketOrder`(선구독→applySellHold 순서) | 시장가 SELL에서 `preSubscribe`(선구독)가 `applySellHold`(무보유 시 throw)보다 먼저 | 실패 시 부분 상태·구독 잔존 결합(a와 연동) | 13·14·28 |
+| e | `OrderPricingService.validateStockTradeable` | KIS 일반 실패(timeout/5xx/네트워크)를 `UntradeableStockException('종목 거래 가능 여부를 확인할 수 없습니다')`로 포괄 은폐 | c와 동류 — 거래불가와 인프라 오류 혼동, 원인 소실 | 4(+일반실패 변형) |
+| f | `OrderService.cancelOrder` + `OrderBookRegistrationService.removeOnCancel` | 취소 시 `removeOrder`+`unregisterLimitOrder`를 **커밋 전 동기** 실행 | 생성 경로의 'DB 커밋 후 Redis' 불변식과 비대칭 — 취소 트랜잭션 롤백 시 오더북만 제거되고 주문 미취소(유령/refcount 누수) | 15·16·17 |
+
+## 3. 수용 기준 충족 요약 (계획 Acceptance criteria)
+
+| 기준 | 증빙 |
+|------|------|
+| 4 컴포넌트 분해 + DAG(순환/역엣지 0) | C1 Pricing(87)/C2 Hold(70)/C3 OrderBookRegistration(60)/C4 Authorization(28) + OrderService 221줄. 생성자 그래프 DAG 실증(architect 45·QA 44) |
+| public 5 흐름 + afterCommit + 홀딩정합 + 권한거부 + KIS폴백경계 + 취소예외 특성화 전량 green, 분해 전후 무수정 | 특성화 35 테스트(28 시나리오), Phase B 4커밋 전부 무수정 green |
+| order service 스코프 라인 커버리지 ≥70% | (C-1 측정치 기록) — Phase A baseline 98.3%(order/service), order 전체 84.0% |
+| Checkstyle 0 / ArchUnit green / suppressions·archunit_store·DTO 필드 diff 0 | Phase B 4커밋 checkstyle 0, 베이스라인 diff 0 |
+| 변경목록 + 버그(a~f) 문서 | 본 문서 §1·§2 |
+| 새 서비스 @Transactional 시맨틱스 보존 | 오케스트레이터 메서드레벨 유지, C1 readOnly, C2 REQUIRED, C3/C4 무트랜잭션(architect 45 §4 PASS) |
+| 이동 메서드 본문 IDENTICAL | QA 44: 정규화 본문 diff 10/10 IDENTICAL(applyBuyHold=save경계 승격, registerAfterCommit=warn-log 부가 예외) |
+
+## 4. 후속(범위 밖, 별도 작업)
+
+- 버그 a~f 사용자 판정 후 별도 수정 커밋(수정 시 "의도된 동작 변경" 목록에 등재).
+- 인접 결합: matching `LimitOrderExecutionService`의 체결-미션 동기 롤백 결함(별도 지적), `AssetService`(395줄) — 이번 범위 밖 연기.
+- 조회 응집: `OrderQueryService`(getOrder/getPendingOrders 분리, Opt-2) 재평가 트리거.
+- 필요 시 controller MockMvc 슬라이스로 order 패키지 전체 커버리지 확장.

--- a/src/main/java/grit/stockIt/domain/order/service/OrderAuthorizationService.java
+++ b/src/main/java/grit/stockIt/domain/order/service/OrderAuthorizationService.java
@@ -1,0 +1,28 @@
+package grit.stockIt.domain.order.service;
+
+import grit.stockIt.domain.account.entity.Account;
+import grit.stockIt.global.exception.ForbiddenException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+// 계좌 소유자 검증 및 인증 사용자 조회
+@Service
+public class OrderAuthorizationService {
+
+    public void ensureAccountOwner(Account account) {
+        String memberEmail = getAuthenticatedEmail();
+        if (!account.getMember().getEmail().equals(memberEmail)) {
+            throw new ForbiddenException("해당 계좌에 대한 권한이 없습니다.");
+        }
+    }
+
+    public String getAuthenticatedEmail() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()
+                || "anonymousUser".equals(authentication.getPrincipal())) {
+            throw new ForbiddenException("로그인이 필요합니다.");
+        }
+        return authentication.getName();
+    }
+}

--- a/src/main/java/grit/stockIt/domain/order/service/OrderBookRegistrationService.java
+++ b/src/main/java/grit/stockIt/domain/order/service/OrderBookRegistrationService.java
@@ -1,0 +1,60 @@
+package grit.stockIt.domain.order.service;
+
+import grit.stockIt.domain.matching.repository.RedisOrderBookRepository;
+import grit.stockIt.domain.order.entity.Order;
+import grit.stockIt.domain.stock.entity.Stock;
+import grit.stockIt.global.util.TransactionHandler;
+import grit.stockIt.global.websocket.manager.OrderSubscriptionCoordinator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+// 오더북 등록/해제 + afterCommit 유령주문 방지 불변식 소유. 무트랜잭션(REQUIRES_NEW 절대 금지 — 불변식 파괴).
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OrderBookRegistrationService {
+
+    private final RedisOrderBookRepository redisOrderBookRepository;
+    private final OrderSubscriptionCoordinator orderSubscriptionCoordinator;
+
+    /**
+     * DB 커밋 후에만 Redis 오더북에 주문을 등록한다(유령 주문 방지).
+     *
+     * <p>계약: 반드시 오케스트레이터의 @Transactional 활성 구간 내에서 동기 호출해야 한다.
+     * REQUIRED join은 안전하지만 REQUIRES_NEW로 새 트랜잭션을 여는 것은 절대 금지 — afterCommit
+     * 불변식(DB 커밋 성공 후에만 오더북 반영)을 파괴한다. 활성 트랜잭션이 없는 상태에서 호출되면
+     * {@link TransactionHandler#afterCommit}의 else 분기가 즉시 실행되어 유령 주문이 발생할 수 있다.
+     */
+    public void registerAfterCommit(Order order, Stock stock) {
+        if (!TransactionSynchronizationManager.isActualTransactionActive()) {
+            log.warn("registerAfterCommit이 활성 트랜잭션 없이 호출됨 - 유령 주문 위험. orderId={} stockCode={}",
+                    order.getOrderId(), stock.getCode());
+        }
+        TransactionHandler.afterCommit(() -> addOrderToRedisAfterCommit(order, stock));
+    }
+
+    // 주문 취소 시 잔량이 남아있으면 오더북에서 제거(커밋 전 동기 실행, 기존 동작 보존)
+    public void removeOnCancel(Order order) {
+        redisOrderBookRepository.removeOrder(order.getOrderId(), order.getStock().getCode(), order.getOrderMethod());
+        orderSubscriptionCoordinator.unregisterLimitOrder(order.getStock().getCode());
+    }
+
+    // 시장가 주문 저장 전 웹소켓 구독 선등록(체결 이벤트 수신을 위해 저장 전에 구독 시작)
+    public void preSubscribe(String stockCode) {
+        orderSubscriptionCoordinator.registerLimitOrder(stockCode);
+    }
+
+    // DB 커밋 후 Redis 오더북에 주문을 추가하는 메서드
+    private void addOrderToRedisAfterCommit(Order order, Stock stock) {
+        try {
+            redisOrderBookRepository.addOrder(order);
+            orderSubscriptionCoordinator.registerLimitOrder(stock.getCode());
+        } catch (Exception e) {
+            log.error("주문 생성 후 Redis 업데이트 실패. orderId={} stockCode={}",
+                    order.getOrderId(), stock.getCode(), e);
+            // 복구 로직은 별도 스케줄러에서 처리
+        }
+    }
+}

--- a/src/main/java/grit/stockIt/domain/order/service/OrderHoldService.java
+++ b/src/main/java/grit/stockIt/domain/order/service/OrderHoldService.java
@@ -1,0 +1,70 @@
+package grit.stockIt.domain.order.service;
+
+import grit.stockIt.domain.account.entity.Account;
+import grit.stockIt.domain.account.entity.AccountStock;
+import grit.stockIt.domain.account.repository.AccountStockRepository;
+import grit.stockIt.domain.order.entity.Order;
+import grit.stockIt.domain.order.entity.OrderHold;
+import grit.stockIt.domain.order.repository.OrderHoldRepository;
+import grit.stockIt.global.exception.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+// 주문 홀딩(현금/보유수량) 확보 및 해제
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class OrderHoldService {
+
+    private final OrderHoldRepository orderHoldRepository;
+    private final AccountStockRepository accountStockRepository;
+
+    public void ensureSufficientCash(Account account, BigDecimal holdAmount) {
+        if (account.getAvailableCash().compareTo(holdAmount) < 0) {
+            throw new BadRequestException("주문 가능 현금이 부족합니다.");
+        }
+    }
+
+    // 저장된 매수 주문에 대해 OrderHold를 생성한다. account.increaseHoldAmount는 save 전에
+    // 오케스트레이터가 별도로 호출해야 한다(OrderHold가 저장된 order의 FK를 필요로 하므로 save 이후 호출).
+    public void applyBuyHold(Order savedOrder, Account account, BigDecimal holdAmount) {
+        OrderHold orderHold = OrderHold.create(savedOrder, account, holdAmount);
+        orderHoldRepository.save(orderHold);
+    }
+
+    public void releaseBuyHold(Order order) {
+        Optional<OrderHold> holdOpt = orderHoldRepository.findById(order.getOrderId());
+        holdOpt.ifPresent(hold -> {
+            Account account = order.getAccount();
+            BigDecimal holdAmount = hold.getHoldAmount();
+            if (holdAmount.signum() > 0) {
+                account.decreaseHoldAmount(holdAmount);
+            }
+            hold.release();
+            orderHoldRepository.save(hold);
+        });
+    }
+
+    public void applySellHold(Order order) {
+        AccountStock accountStock = accountStockRepository.findByAccountAndStock(order.getAccount(), order.getStock())
+                .orElseThrow(() -> new BadRequestException("보유 중인 종목이 없습니다."));
+        accountStock.increaseHoldQuantity(order.getRemainingQuantity());
+        accountStockRepository.save(accountStock);
+    }
+
+    public void releaseSellHold(Order order) {
+        int releaseQuantity = order.getRemainingQuantity();
+        if (releaseQuantity <= 0) {
+            return;
+        }
+        accountStockRepository.findByAccountAndStock(order.getAccount(), order.getStock())
+                .ifPresent(accountStock -> {
+                    accountStock.decreaseHoldQuantity(releaseQuantity);
+                    accountStockRepository.save(accountStock);
+                });
+    }
+}

--- a/src/main/java/grit/stockIt/domain/order/service/OrderPricingService.java
+++ b/src/main/java/grit/stockIt/domain/order/service/OrderPricingService.java
@@ -1,0 +1,87 @@
+package grit.stockIt.domain.order.service;
+
+import grit.stockIt.domain.matching.repository.RedisMarketDataRepository;
+import grit.stockIt.domain.order.entity.Order;
+import grit.stockIt.domain.stock.service.StockDetailService;
+import grit.stockIt.global.exception.BadRequestException;
+import grit.stockIt.global.exception.UntradeableStockException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Optional;
+
+// 주문 pricing + tradeability guard
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrderPricingService {
+
+    private final RedisMarketDataRepository redisMarketDataRepository;
+    private final StockDetailService stockDetailService;
+
+    @Value("${order.market.hold-buffer-rate:0.05}")
+    private BigDecimal marketHoldBufferRate;
+
+    public BigDecimal calculateHoldAmount(Order order) {
+        return order.getPrice().multiply(BigDecimal.valueOf(order.getRemainingQuantity()));
+    }
+
+    // 시장가 주문 홀딩 금액 계산
+    public BigDecimal calculateMarketHoldAmount(String stockCode, int quantity) {
+        // 1. Redis 캐시에서 먼저 조회
+        BigDecimal lastPrice = redisMarketDataRepository.getLastPrice(stockCode)
+                .orElseGet(() -> {
+                    // 2. 캐시에 없으면 KIS API 호출
+                    log.info("캐시에 현재가가 없어 KIS API 호출: stockCode={}", stockCode);
+                    try {
+                        BigDecimal price = stockDetailService.getCurrentPrice(stockCode)
+                                .block(java.time.Duration.ofSeconds(5));
+                        if (price == null || price.signum() <= 0) {
+                            throw new BadRequestException("KIS API에서 현재가를 가져올 수 없습니다.");
+                        }
+                        // KIS API 결과는 StockDetailService에서 이미 Redis에 저장됨
+                        return price;
+                    } catch (Exception e) {
+                        log.error("KIS API 현재가 조회 실패: stockCode={}", stockCode, e);
+                        throw new BadRequestException("최근 체결가 정보를 찾을 수 없습니다.");
+                    }
+                });
+
+        if (lastPrice.signum() <= 0) {
+            throw new BadRequestException("최근 체결가가 유효하지 않습니다.");
+        }
+        BigDecimal bufferRate = Optional.ofNullable(marketHoldBufferRate).orElse(BigDecimal.valueOf(0.05));
+        if (bufferRate.signum() < 0) {
+            bufferRate = BigDecimal.ZERO;
+        }
+        BigDecimal bufferFactor = BigDecimal.ONE.add(bufferRate);
+        BigDecimal baseAmount = lastPrice.multiply(BigDecimal.valueOf(quantity));
+        return baseAmount.multiply(bufferFactor).setScale(2, RoundingMode.UP);
+    }
+
+    // 거래 가능 종목인지 검증
+    public void validateStockTradeable(String stockCode) {
+        try {
+            var stockDetail = stockDetailService.getStockDetail(stockCode)
+                    .block(java.time.Duration.ofSeconds(5));
+
+            if (stockDetail == null || !Boolean.TRUE.equals(stockDetail.tradeable())) {
+                String reason = stockDetail != null && stockDetail.untradeableReason() != null
+                        ? stockDetail.untradeableReason()
+                        : "이 종목은 AI 분석이 불가능하여 거래가 제한됩니다.";
+                throw new UntradeableStockException(reason);
+            }
+        } catch (UntradeableStockException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("종목 거래 가능 여부 확인 실패: stockCode={}", stockCode, e);
+            throw new UntradeableStockException("종목 거래 가능 여부를 확인할 수 없습니다.");
+        }
+    }
+}

--- a/src/main/java/grit/stockIt/domain/order/service/OrderService.java
+++ b/src/main/java/grit/stockIt/domain/order/service/OrderService.java
@@ -2,7 +2,6 @@ package grit.stockIt.domain.order.service;
 
 import grit.stockIt.domain.account.entity.Account;
 import grit.stockIt.domain.account.repository.AccountRepository;
-import grit.stockIt.domain.matching.repository.RedisOrderBookRepository;
 import grit.stockIt.domain.order.dto.LimitOrderCreateRequest;
 import grit.stockIt.domain.order.dto.MarketOrderCreateRequest;
 import grit.stockIt.domain.order.dto.OrderResponse;
@@ -15,8 +14,6 @@ import grit.stockIt.domain.order.repository.OrderRepository;
 import grit.stockIt.domain.stock.entity.Stock;
 import grit.stockIt.domain.stock.repository.StockRepository;
 import grit.stockIt.global.exception.BadRequestException;
-import grit.stockIt.global.util.TransactionHandler;
-import grit.stockIt.global.websocket.manager.OrderSubscriptionCoordinator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -24,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
 import java.util.List;
 
+// 주문 오케스트레이션(권한·가격·홀딩·오더북 조율)
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -32,11 +30,10 @@ public class OrderService {
     private final OrderRepository orderRepository;
     private final AccountRepository accountRepository;
     private final StockRepository stockRepository;
-    private final RedisOrderBookRepository redisOrderBookRepository;
-    private final OrderSubscriptionCoordinator orderSubscriptionCoordinator;
     private final OrderAuthorizationService orderAuthorizationService;
     private final OrderPricingService orderPricingService;
     private final OrderHoldService orderHoldService;
+    private final OrderBookRegistrationService orderBookRegistrationService;
 
     // 지정가 주문 생성
     @Transactional
@@ -82,9 +79,7 @@ public class OrderService {
         }
 
         // DB 커밋 후에만 Redis 오더북에 주문 추가 (유령 주문 방지)
-        TransactionHandler.afterCommit(() -> 
-            addOrderToRedisAfterCommit(savedOrder, stock)
-        );
+        orderBookRegistrationService.registerAfterCommit(savedOrder, stock);
 
         log.info("지정가 주문 생성 완료: orderId={} stock={} quantity={}", savedOrder.getOrderId(), stock.getCode(), savedOrder.getQuantity());
         return OrderResponse.from(savedOrder);
@@ -120,7 +115,7 @@ public class OrderService {
 
         // 시장가 주문도 지정가 주문처럼 웹소켓 구독을 먼저 시작
         // 최근 체결가 조회 전에 구독이 시작되어 체결 이벤트를 받을 수 있도록 함
-        orderSubscriptionCoordinator.registerLimitOrder(stock.getCode());
+        orderBookRegistrationService.preSubscribe(stock.getCode());
 
         BigDecimal holdAmount = BigDecimal.ZERO;
         if (orderMethod == OrderMethod.SELL) {
@@ -138,9 +133,7 @@ public class OrderService {
         }
 
         // DB 커밋 후에만 Redis 오더북에 주문 추가 (유령 주문 방지)
-        TransactionHandler.afterCommit(() -> 
-            addOrderToRedisAfterCommit(savedOrder, stock)
-        );
+        orderBookRegistrationService.registerAfterCommit(savedOrder, stock);
 
         log.info("시장가 주문 생성 완료: orderId={} stock={} quantity={}", savedOrder.getOrderId(), stock.getCode(), savedOrder.getQuantity());
         return OrderResponse.from(savedOrder);
@@ -165,8 +158,7 @@ public class OrderService {
         orderRepository.save(order);
 
         if (order.getRemainingQuantity() > 0) {
-            redisOrderBookRepository.removeOrder(order.getOrderId(), order.getStock().getCode(), order.getOrderMethod());
-            orderSubscriptionCoordinator.unregisterLimitOrder(order.getStock().getCode());
+            orderBookRegistrationService.removeOnCancel(order);
         }
 
         if (order.getOrderMethod() == OrderMethod.BUY) {
@@ -225,18 +217,6 @@ public class OrderService {
 
         log.info("대기 주문 조회 완료: accountId={}, count={}", accountId, orderItems.size());
         return new PendingOrdersResponse(orderItems);
-    }
-
-    // DB 커밋 후 Redis 오더북에 주문을 추가하는 메서드
-    private void addOrderToRedisAfterCommit(Order order, Stock stock) {
-        try {
-            redisOrderBookRepository.addOrder(order);
-            orderSubscriptionCoordinator.registerLimitOrder(stock.getCode());
-        } catch (Exception e) {
-            log.error("주문 생성 후 Redis 업데이트 실패. orderId={} stockCode={}", 
-                order.getOrderId(), stock.getCode(), e);
-            // 복구 로직은 별도 스케줄러에서 처리
-        }
     }
 
 }

--- a/src/main/java/grit/stockIt/domain/order/service/OrderService.java
+++ b/src/main/java/grit/stockIt/domain/order/service/OrderService.java
@@ -21,15 +21,12 @@ import grit.stockIt.domain.stock.entity.Stock;
 import grit.stockIt.domain.stock.repository.StockRepository;
 import grit.stockIt.domain.stock.service.StockDetailService;
 import grit.stockIt.global.exception.BadRequestException;
-import grit.stockIt.global.exception.ForbiddenException;
 import grit.stockIt.global.exception.UntradeableStockException;
 import grit.stockIt.global.util.TransactionHandler;
 import grit.stockIt.global.websocket.manager.OrderSubscriptionCoordinator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -52,6 +49,7 @@ public class OrderService {
     private final AccountStockRepository accountStockRepository;
     private final RedisMarketDataRepository redisMarketDataRepository;
     private final StockDetailService stockDetailService;
+    private final OrderAuthorizationService orderAuthorizationService;
 
     @Value("${order.market.hold-buffer-rate:0.05}")
     private BigDecimal marketHoldBufferRate;
@@ -62,7 +60,7 @@ public class OrderService {
         Account account = accountRepository.findByIdWithLock(request.accountId())
                 .orElseThrow(() -> new BadRequestException("계좌를 찾을 수 없습니다."));
 
-        ensureAccountOwner(account);
+        orderAuthorizationService.ensureAccountOwner(account);
 
         Stock stock = stockRepository.findById(request.stockCode())
                 .orElseThrow(() -> new BadRequestException("존재하지 않는 종목입니다."));
@@ -115,7 +113,7 @@ public class OrderService {
         Account account = accountRepository.findByIdWithLock(request.accountId())
                 .orElseThrow(() -> new BadRequestException("계좌를 찾을 수 없습니다."));
 
-        ensureAccountOwner(account);
+        orderAuthorizationService.ensureAccountOwner(account);
 
         Stock stock = stockRepository.findById(request.stockCode())
                 .orElseThrow(() -> new BadRequestException("존재하지 않는 종목입니다."));
@@ -172,7 +170,7 @@ public class OrderService {
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new BadRequestException("주문을 찾을 수 없습니다."));
 
-        ensureAccountOwner(order.getAccount());
+        orderAuthorizationService.ensureAccountOwner(order.getAccount());
 
         if (order.getStatus() == OrderStatus.CANCELLED) {
             throw new BadRequestException("이미 취소된 주문입니다.");
@@ -203,7 +201,7 @@ public class OrderService {
     public OrderResponse getOrder(Long orderId) {
         Order order = orderRepository.findByIdWithStockAndAccount(orderId)
                 .orElseThrow(() -> new BadRequestException("주문을 찾을 수 없습니다."));
-        ensureAccountOwner(order.getAccount());
+        orderAuthorizationService.ensureAccountOwner(order.getAccount());
         return OrderResponse.from(order);
     }
 
@@ -213,7 +211,7 @@ public class OrderService {
         Account account = accountRepository.findById(accountId)
                 .orElseThrow(() -> new BadRequestException("계좌를 찾을 수 없습니다."));
 
-        ensureAccountOwner(account);
+        orderAuthorizationService.ensureAccountOwner(account);
 
         // 대기 주문 목록 조회 (PENDING, PARTIALLY_FILLED)
         List<Order> pendingOrders = orderRepository.findAllPendingOrdersByAccountId(
@@ -332,22 +330,6 @@ public class OrderService {
                 order.getOrderId(), stock.getCode(), e);
             // 복구 로직은 별도 스케줄러에서 처리
         }
-    }
-
-    private void ensureAccountOwner(Account account) {
-        String memberEmail = getAuthenticatedEmail();
-        if (!account.getMember().getEmail().equals(memberEmail)) {
-            throw new ForbiddenException("해당 계좌에 대한 권한이 없습니다.");
-        }
-    }
-
-    private String getAuthenticatedEmail() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated()
-                || "anonymousUser".equals(authentication.getPrincipal())) {
-            throw new ForbiddenException("로그인이 필요합니다.");
-        }
-        return authentication.getName();
     }
 
     // 거래 가능 종목인지 검증

--- a/src/main/java/grit/stockIt/domain/order/service/OrderService.java
+++ b/src/main/java/grit/stockIt/domain/order/service/OrderService.java
@@ -4,7 +4,6 @@ import grit.stockIt.domain.account.entity.Account;
 import grit.stockIt.domain.account.repository.AccountRepository;
 import grit.stockIt.domain.account.entity.AccountStock;
 import grit.stockIt.domain.account.repository.AccountStockRepository;
-import grit.stockIt.domain.matching.repository.RedisMarketDataRepository;
 import grit.stockIt.domain.matching.repository.RedisOrderBookRepository;
 import grit.stockIt.domain.order.dto.LimitOrderCreateRequest;
 import grit.stockIt.domain.order.dto.MarketOrderCreateRequest;
@@ -19,19 +18,14 @@ import grit.stockIt.domain.order.repository.OrderHoldRepository;
 import grit.stockIt.domain.order.repository.OrderRepository;
 import grit.stockIt.domain.stock.entity.Stock;
 import grit.stockIt.domain.stock.repository.StockRepository;
-import grit.stockIt.domain.stock.service.StockDetailService;
 import grit.stockIt.global.exception.BadRequestException;
-import grit.stockIt.global.exception.UntradeableStockException;
 import grit.stockIt.global.util.TransactionHandler;
 import grit.stockIt.global.websocket.manager.OrderSubscriptionCoordinator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.List;
 import java.util.Optional;
 
@@ -47,12 +41,8 @@ public class OrderService {
     private final OrderSubscriptionCoordinator orderSubscriptionCoordinator;
     private final OrderHoldRepository orderHoldRepository;
     private final AccountStockRepository accountStockRepository;
-    private final RedisMarketDataRepository redisMarketDataRepository;
-    private final StockDetailService stockDetailService;
     private final OrderAuthorizationService orderAuthorizationService;
-
-    @Value("${order.market.hold-buffer-rate:0.05}")
-    private BigDecimal marketHoldBufferRate;
+    private final OrderPricingService orderPricingService;
 
     // 지정가 주문 생성
     @Transactional
@@ -72,7 +62,7 @@ public class OrderService {
 
         // 매수 주문인 경우 거래 가능 종목인지 검증
         if (orderMethod == OrderMethod.BUY) {
-            validateStockTradeable(request.stockCode());
+            orderPricingService.validateStockTradeable(request.stockCode());
         }
 
         Order order = Order.createLimitOrder(
@@ -85,7 +75,7 @@ public class OrderService {
 
         BigDecimal holdAmount = BigDecimal.ZERO;
         if (orderMethod == OrderMethod.BUY) {
-            holdAmount = calculateHoldAmount(order); // 주문 금액 계산
+            holdAmount = orderPricingService.calculateHoldAmount(order); // 주문 금액 계산
             ensureSufficientCash(account, holdAmount); // 주문 가능 현금 확인
             account.increaseHoldAmount(holdAmount); // 홀딩 금액 증가
         } else if (orderMethod == OrderMethod.SELL) {
@@ -125,7 +115,7 @@ public class OrderService {
 
         // 매수 주문인 경우 거래 가능 종목인지 검증
         if (orderMethod == OrderMethod.BUY) {
-            validateStockTradeable(request.stockCode());
+            orderPricingService.validateStockTradeable(request.stockCode());
         }
 
         Order order = Order.createMarketOrder(
@@ -143,7 +133,7 @@ public class OrderService {
         if (orderMethod == OrderMethod.SELL) {
             applySellHold(order);
         } else if (orderMethod == OrderMethod.BUY) {
-            holdAmount = calculateMarketHoldAmount(stock.getCode(), order.getQuantity());
+            holdAmount = orderPricingService.calculateMarketHoldAmount(stock.getCode(), order.getQuantity());
             ensureSufficientCash(account, holdAmount);
             account.increaseHoldAmount(holdAmount);
         }
@@ -245,43 +235,6 @@ public class OrderService {
         return new PendingOrdersResponse(orderItems);
     }
 
-    private BigDecimal calculateHoldAmount(Order order) {
-        return order.getPrice().multiply(BigDecimal.valueOf(order.getRemainingQuantity()));
-    }
-
-    // 시장가 주문 홀딩 금액 계산
-    private BigDecimal calculateMarketHoldAmount(String stockCode, int quantity) {
-        // 1. Redis 캐시에서 먼저 조회
-        BigDecimal lastPrice = redisMarketDataRepository.getLastPrice(stockCode)
-                .orElseGet(() -> {
-                    // 2. 캐시에 없으면 KIS API 호출
-                    log.info("캐시에 현재가가 없어 KIS API 호출: stockCode={}", stockCode);
-                    try {
-                        BigDecimal price = stockDetailService.getCurrentPrice(stockCode)
-                                .block(java.time.Duration.ofSeconds(5));
-                        if (price == null || price.signum() <= 0) {
-                            throw new BadRequestException("KIS API에서 현재가를 가져올 수 없습니다.");
-                        }
-                        // KIS API 결과는 StockDetailService에서 이미 Redis에 저장됨
-                        return price;
-                    } catch (Exception e) {
-                        log.error("KIS API 현재가 조회 실패: stockCode={}", stockCode, e);
-                        throw new BadRequestException("최근 체결가 정보를 찾을 수 없습니다.");
-                    }
-                });
-        
-        if (lastPrice.signum() <= 0) {
-            throw new BadRequestException("최근 체결가가 유효하지 않습니다.");
-        }
-        BigDecimal bufferRate = Optional.ofNullable(marketHoldBufferRate).orElse(BigDecimal.valueOf(0.05));
-        if (bufferRate.signum() < 0) {
-            bufferRate = BigDecimal.ZERO;
-        }
-        BigDecimal bufferFactor = BigDecimal.ONE.add(bufferRate);
-        BigDecimal baseAmount = lastPrice.multiply(BigDecimal.valueOf(quantity));
-        return baseAmount.multiply(bufferFactor).setScale(2, RoundingMode.UP);
-    }
-
     private void ensureSufficientCash(Account account, BigDecimal holdAmount) {
         if (account.getAvailableCash().compareTo(holdAmount) < 0) {
             throw new BadRequestException("주문 가능 현금이 부족합니다.");
@@ -332,24 +285,4 @@ public class OrderService {
         }
     }
 
-    // 거래 가능 종목인지 검증
-    private void validateStockTradeable(String stockCode) {
-        try {
-            var stockDetail = stockDetailService.getStockDetail(stockCode)
-                    .block(java.time.Duration.ofSeconds(5));
-            
-            if (stockDetail == null || !Boolean.TRUE.equals(stockDetail.tradeable())) {
-                String reason = stockDetail != null && stockDetail.untradeableReason() != null
-                        ? stockDetail.untradeableReason()
-                        : "이 종목은 AI 분석이 불가능하여 거래가 제한됩니다.";
-                throw new UntradeableStockException(reason);
-            }
-        } catch (UntradeableStockException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("종목 거래 가능 여부 확인 실패: stockCode={}", stockCode, e);
-            throw new UntradeableStockException("종목 거래 가능 여부를 확인할 수 없습니다.");
-        }
-    }
 }
-

--- a/src/main/java/grit/stockIt/domain/order/service/OrderService.java
+++ b/src/main/java/grit/stockIt/domain/order/service/OrderService.java
@@ -2,19 +2,15 @@ package grit.stockIt.domain.order.service;
 
 import grit.stockIt.domain.account.entity.Account;
 import grit.stockIt.domain.account.repository.AccountRepository;
-import grit.stockIt.domain.account.entity.AccountStock;
-import grit.stockIt.domain.account.repository.AccountStockRepository;
 import grit.stockIt.domain.matching.repository.RedisOrderBookRepository;
 import grit.stockIt.domain.order.dto.LimitOrderCreateRequest;
 import grit.stockIt.domain.order.dto.MarketOrderCreateRequest;
 import grit.stockIt.domain.order.dto.OrderResponse;
 import grit.stockIt.domain.order.dto.PendingOrdersResponse;
 import grit.stockIt.domain.order.entity.Order;
-import grit.stockIt.domain.order.entity.OrderHold;
 import grit.stockIt.domain.order.entity.OrderMethod;
 import grit.stockIt.domain.order.entity.OrderStatus;
 import grit.stockIt.domain.order.entity.OrderType;
-import grit.stockIt.domain.order.repository.OrderHoldRepository;
 import grit.stockIt.domain.order.repository.OrderRepository;
 import grit.stockIt.domain.stock.entity.Stock;
 import grit.stockIt.domain.stock.repository.StockRepository;
@@ -27,7 +23,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
 import java.util.List;
-import java.util.Optional;
 
 @Slf4j
 @Service
@@ -39,10 +34,9 @@ public class OrderService {
     private final StockRepository stockRepository;
     private final RedisOrderBookRepository redisOrderBookRepository;
     private final OrderSubscriptionCoordinator orderSubscriptionCoordinator;
-    private final OrderHoldRepository orderHoldRepository;
-    private final AccountStockRepository accountStockRepository;
     private final OrderAuthorizationService orderAuthorizationService;
     private final OrderPricingService orderPricingService;
+    private final OrderHoldService orderHoldService;
 
     // 지정가 주문 생성
     @Transactional
@@ -76,16 +70,15 @@ public class OrderService {
         BigDecimal holdAmount = BigDecimal.ZERO;
         if (orderMethod == OrderMethod.BUY) {
             holdAmount = orderPricingService.calculateHoldAmount(order); // 주문 금액 계산
-            ensureSufficientCash(account, holdAmount); // 주문 가능 현금 확인
+            orderHoldService.ensureSufficientCash(account, holdAmount); // 주문 가능 현금 확인
             account.increaseHoldAmount(holdAmount); // 홀딩 금액 증가
         } else if (orderMethod == OrderMethod.SELL) {
-            applySellHold(order);
+            orderHoldService.applySellHold(order);
         }
 
         Order savedOrder = orderRepository.save(order);
         if (orderMethod == OrderMethod.BUY) {
-            OrderHold orderHold = OrderHold.create(savedOrder, account, holdAmount);
-            orderHoldRepository.save(orderHold);
+            orderHoldService.applyBuyHold(savedOrder, account, holdAmount);
         }
 
         // DB 커밋 후에만 Redis 오더북에 주문 추가 (유령 주문 방지)
@@ -131,18 +124,17 @@ public class OrderService {
 
         BigDecimal holdAmount = BigDecimal.ZERO;
         if (orderMethod == OrderMethod.SELL) {
-            applySellHold(order);
+            orderHoldService.applySellHold(order);
         } else if (orderMethod == OrderMethod.BUY) {
             holdAmount = orderPricingService.calculateMarketHoldAmount(stock.getCode(), order.getQuantity());
-            ensureSufficientCash(account, holdAmount);
+            orderHoldService.ensureSufficientCash(account, holdAmount);
             account.increaseHoldAmount(holdAmount);
         }
 
         Order savedOrder = orderRepository.save(order);
 
         if (orderMethod == OrderMethod.BUY) {
-            OrderHold orderHold = OrderHold.create(savedOrder, account, holdAmount);
-            orderHoldRepository.save(orderHold);
+            orderHoldService.applyBuyHold(savedOrder, account, holdAmount);
         }
 
         // DB 커밋 후에만 Redis 오더북에 주문 추가 (유령 주문 방지)
@@ -178,9 +170,9 @@ public class OrderService {
         }
 
         if (order.getOrderMethod() == OrderMethod.BUY) {
-            releaseBuyHold(order);
+            orderHoldService.releaseBuyHold(order);
         } else if (order.getOrderMethod() == OrderMethod.SELL) {
-            releaseSellHold(order);
+            orderHoldService.releaseSellHold(order);
         }
 
         log.info("주문 취소 완료: orderId={}", orderId);
@@ -233,44 +225,6 @@ public class OrderService {
 
         log.info("대기 주문 조회 완료: accountId={}, count={}", accountId, orderItems.size());
         return new PendingOrdersResponse(orderItems);
-    }
-
-    private void ensureSufficientCash(Account account, BigDecimal holdAmount) {
-        if (account.getAvailableCash().compareTo(holdAmount) < 0) {
-            throw new BadRequestException("주문 가능 현금이 부족합니다.");
-        }
-    }
-
-    private void releaseBuyHold(Order order) {
-        Optional<OrderHold> holdOpt = orderHoldRepository.findById(order.getOrderId());
-        holdOpt.ifPresent(hold -> {
-            Account account = order.getAccount();
-            BigDecimal holdAmount = hold.getHoldAmount();
-            if (holdAmount.signum() > 0) {
-                account.decreaseHoldAmount(holdAmount);
-            }
-            hold.release();
-            orderHoldRepository.save(hold);
-        });
-    }
-
-    private void applySellHold(Order order) {
-        AccountStock accountStock = accountStockRepository.findByAccountAndStock(order.getAccount(), order.getStock())
-                .orElseThrow(() -> new BadRequestException("보유 중인 종목이 없습니다."));
-        accountStock.increaseHoldQuantity(order.getRemainingQuantity());
-        accountStockRepository.save(accountStock);
-    }
-
-    private void releaseSellHold(Order order) {
-        int releaseQuantity = order.getRemainingQuantity();
-        if (releaseQuantity <= 0) {
-            return;
-        }
-        accountStockRepository.findByAccountAndStock(order.getAccount(), order.getStock())
-                .ifPresent(accountStock -> {
-                    accountStock.decreaseHoldQuantity(releaseQuantity);
-                    accountStockRepository.save(accountStock);
-                });
     }
 
     // DB 커밋 후 Redis 오더북에 주문을 추가하는 메서드

--- a/src/test/java/grit/stockIt/domain/order/service/OrderBookInvariantCharacterizationTest.java
+++ b/src/test/java/grit/stockIt/domain/order/service/OrderBookInvariantCharacterizationTest.java
@@ -32,7 +32,6 @@ import reactor.core.publisher.Mono;
 
 import java.math.BigDecimal;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/grit/stockIt/domain/order/service/OrderBookInvariantCharacterizationTest.java
+++ b/src/test/java/grit/stockIt/domain/order/service/OrderBookInvariantCharacterizationTest.java
@@ -1,0 +1,252 @@
+package grit.stockIt.domain.order.service;
+
+import grit.stockIt.domain.account.entity.Account;
+import grit.stockIt.domain.account.repository.AccountRepository;
+import grit.stockIt.domain.contest.entity.Contest;
+import grit.stockIt.domain.contest.repository.ContestRepository;
+import grit.stockIt.domain.matching.repository.RedisOrderBookRepository;
+import grit.stockIt.domain.member.entity.AuthProvider;
+import grit.stockIt.domain.member.entity.Member;
+import grit.stockIt.domain.member.repository.MemberRepository;
+import grit.stockIt.domain.order.dto.LimitOrderCreateRequest;
+import grit.stockIt.domain.order.dto.MarketOrderCreateRequest;
+import grit.stockIt.domain.order.entity.Order;
+import grit.stockIt.domain.order.entity.OrderMethod;
+import grit.stockIt.domain.order.repository.OrderRepository;
+import grit.stockIt.domain.stock.entity.Stock;
+import grit.stockIt.domain.stock.repository.StockRepository;
+import grit.stockIt.domain.stock.service.StockDetailService;
+import grit.stockIt.global.exception.BadRequestException;
+import grit.stockIt.global.support.IntegrationTestSupport;
+import grit.stockIt.global.websocket.manager.OrderSubscriptionCoordinator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import reactor.core.publisher.Mono;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+// 컨테이너·프로파일 설정은 IntegrationTestSupport 싱글턴을 상속.
+// 오더북(afterCommit) 불변식은 실 커밋에 의존하므로 테스트 메서드에 @Transactional을 붙이지 않는다
+// (스프링 @Transactional 롤백 테스트는 afterCommit 콜백을 발화시키지 않아 계획에서 금지됨).
+@DisplayName("OrderService 오더북(afterCommit) 불변식 특성화 테스트 (Phase A, 프로덕션 무수정)")
+class OrderBookInvariantCharacterizationTest extends IntegrationTestSupport {
+
+    @Autowired
+    private OrderService orderService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ContestRepository contestRepository;
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    @Autowired
+    private StockRepository stockRepository;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @SpyBean
+    private RedisOrderBookRepository redisOrderBookRepository;
+
+    @SpyBean
+    private OrderSubscriptionCoordinator orderSubscriptionCoordinator;
+
+    @MockBean
+    private StockDetailService stockDetailService;
+
+    private Member testMember;
+    private Contest testContest;
+
+    @BeforeEach
+    void setUp() {
+        // @SpyBean은 캐시된 컨텍스트에서 테스트 간 공유되므로, 각 테스트 시작 시 stub·호출기록을 초기화해
+        // 이전 테스트의 addOrder/register 호출이나 doThrow 스텁이 누출되지 않게 한다(격리).
+        org.mockito.Mockito.reset(redisOrderBookRepository, orderSubscriptionCoordinator);
+        String uniqueId = UUID.randomUUID().toString().substring(0, 8);
+        testMember = Member.builder()
+                .name("테스트 사용자 " + uniqueId)
+                .email("test" + uniqueId + "@test.com")
+                .provider(AuthProvider.LOCAL)
+                .build();
+        testMember = memberRepository.save(testMember);
+
+        testContest = Contest.builder()
+                .contestName("테스트 대회 " + uniqueId)
+                .startDate(java.time.LocalDateTime.now())
+                .seedMoney(10000000L)
+                .commissionRate(new BigDecimal("0.0000"))
+                .isDefault(false)
+                .build();
+        testContest = contestRepository.save(testContest);
+
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(testMember.getEmail(), null, List.of())
+        );
+
+        // BUY 주문은 매수 시 항상 validateStockTradeable(getStockDetail)을 먼저 통과해야
+        // 이후 현금 검증/afterCommit 경로에 도달한다. 기본적으로 거래 가능으로 스텁.
+        org.mockito.Mockito.when(stockDetailService.getStockDetail(anyString()))
+                .thenReturn(Mono.just(tradeableStockDetail()));
+    }
+
+    private grit.stockIt.domain.stock.dto.StockDetailResponse tradeableStockDetail() {
+        return new grit.stockIt.domain.stock.dto.StockDetailResponse(
+                "000000", "테스트", 100, 0, "0", null,
+                0L, 0L, 0L, 0.0, 0.0, 0.0, 0, 0, 0, 0, 0,
+                null, null, true, null, null, null
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private Account createAccount(BigDecimal cash) {
+        Account account = Account.builder()
+                .member(testMember)
+                .contest(testContest)
+                .accountName("테스트 계좌 " + UUID.randomUUID())
+                .cash(cash)
+                .holdAmount(BigDecimal.ZERO)
+                .isDefault(false)
+                .build();
+        return accountRepository.save(account);
+    }
+
+    private Stock createStock() {
+        String code = "T" + UUID.randomUUID().toString().replace("-", "").substring(0, 5).toUpperCase();
+        Stock stock = Stock.builder()
+                .code(code)
+                .name("테스트종목-" + code)
+                .build();
+        return stockRepository.save(stock);
+    }
+
+    // ===== 27a: 정상 커밋 → 오더북 반영 =====
+    @Test
+    @DisplayName("27a. 지정가 주문 정상 커밋 시 afterCommit 훅에서 addOrder가 1회 호출되어 오더북에 반영된다")
+    void afterCommit_normalCommit_addsOrderToOrderBook() {
+        // given: 매수 주문에 필요한 충분한 현금을 가진 계좌
+        Account account = createAccount(new BigDecimal("1000000"));
+        Stock stock = createStock();
+        var request = new LimitOrderCreateRequest(account.getAccountId(), stock.getCode(),
+                new BigDecimal("100"), 10, OrderMethod.BUY);
+
+        // when
+        var response = orderService.createLimitOrder(request);
+
+        // then: afterCommit이 커밋 시점에 동기 발화되어 addOrder가 정확히 1회 호출됨
+        verify(redisOrderBookRepository, times(1)).addOrder(any(Order.class));
+        assertThat(redisOrderBookRepository.exists(response.orderId(), stock.getCode(), OrderMethod.BUY)).isTrue();
+    }
+
+    // ===== 27b: 강제(예외 기반) 롤백 → 오더북 미반영 =====
+    @Test
+    @DisplayName("27b. 현금 부족으로 트랜잭션이 예외 롤백되면 afterCommit이 발화되지 않아 addOrder가 호출되지 않는다")
+    void afterCommit_exceptionBasedRollback_neverAddsOrderToOrderBook() {
+        // given: 홀딩 가능 금액보다 부족한 현금 계좌 (BadRequestException 유발용, @Transactional 롤백 테스트 아님)
+        Account account = createAccount(new BigDecimal("1"));
+        Stock stock = createStock();
+        var request = new LimitOrderCreateRequest(account.getAccountId(), stock.getCode(),
+                new BigDecimal("100"), 10, OrderMethod.BUY);
+
+        // when / then: ensureSufficientCash에서 BadRequestException → 트랜잭션 전체 롤백
+        org.junit.jupiter.api.Assertions.assertThrows(BadRequestException.class,
+                () -> orderService.createLimitOrder(request));
+
+        // then: afterCommit이 등록조차 되지 않으므로(예외가 save 이전에 발생) addOrder 미호출
+        verify(redisOrderBookRepository, never()).addOrder(any(Order.class));
+        List<Order> orders = orderRepository.findAllPendingOrdersByAccountId(
+                account.getAccountId(),
+                List.of(grit.stockIt.domain.order.entity.OrderStatus.PENDING)
+        );
+        assertThat(orders).isEmpty();
+    }
+
+    // ===== 27c: addOrder 예외 → DB 커밋 유지, 오더북 미반영, 예외 미전파 =====
+    @Test
+    @DisplayName("27c. afterCommit 훅 내 addOrder가 예외를 던져도 주문은 DB에 커밋되고 예외는 삼켜지며 오더북은 미반영된다")
+    void afterCommit_addOrderThrows_orderStillCommitted_exceptionSwallowed() {
+        // given
+        Account account = createAccount(new BigDecimal("1000000"));
+        Stock stock = createStock();
+        var request = new LimitOrderCreateRequest(account.getAccountId(), stock.getCode(),
+                new BigDecimal("100"), 10, OrderMethod.BUY);
+
+        doThrow(new RuntimeException("simulated redis addOrder failure"))
+                .when(redisOrderBookRepository).addOrder(any(Order.class));
+
+        // when: addOrderToRedisAfterCommit의 catch(Exception)가 예외를 삼키므로 서비스 호출은 정상 반환됨
+        var response = orderService.createLimitOrder(request);
+
+        // then: 주문은 DB에 커밋되어 조회 가능
+        Order saved = orderRepository.findById(response.orderId()).orElseThrow();
+        assertThat(saved.getOrderId()).isEqualTo(response.orderId());
+
+        // then: addOrder는 호출되었으나(예외 발생) 오더북에는 실제로 반영되지 않음
+        verify(redisOrderBookRepository, times(1)).addOrder(any(Order.class));
+        assertThat(redisOrderBookRepository.exists(response.orderId(), stock.getCode(), OrderMethod.BUY)).isFalse();
+
+        // 특이사항: addOrderToRedisAfterCommit의 try 블록에서 addOrder 예외 시 이후의
+        // registerLimitOrder(stock.getCode()) 호출도 함께 스킵된다 (현재 동작 그대로 동결).
+        verify(orderSubscriptionCoordinator, never()).registerLimitOrder(stock.getCode());
+    }
+
+    // ===== 28: 시장가 KIS 실패 롤백 후 선구독 잔존 (버그 의심 a) =====
+    @Test
+    @DisplayName("28(버그 a). 시장가 매수 시 registerLimitOrder는 save/afterCommit 이전에 직접 호출되어, "
+            + "이후 현재가 조회 실패로 트랜잭션이 롤백돼도 구독 등록 호출은 잔존하고 unregister는 발생하지 않는다")
+    void marketOrder_kisFailureRollback_subscriptionRegistrationLeaksAndNeverUnregistered() {
+        // given: 현재가 캐시 없음(신규 종목 코드) + KIS 현재가 조회 실패로 Mono.error
+        Account account = createAccount(new BigDecimal("1000000"));
+        Stock stock = createStock();
+        var request = new MarketOrderCreateRequest(account.getAccountId(), stock.getCode(), 10, OrderMethod.BUY);
+
+        org.mockito.Mockito.when(stockDetailService.getCurrentPrice(anyString()))
+                .thenReturn(Mono.error(new RuntimeException("KIS API 장애(시뮬레이션)")));
+
+        // when / then: calculateMarketHoldAmount 내부에서 현재가 조회 실패 → BadRequestException → 트랜잭션 롤백
+        org.junit.jupiter.api.Assertions.assertThrows(BadRequestException.class,
+                () -> orderService.createMarketOrder(request));
+
+        // then(버그 a 동결): registerLimitOrder는 저장/afterCommit 이전에 직접 호출되므로 롤백과 무관하게 잔존
+        verify(orderSubscriptionCoordinator, times(1)).registerLimitOrder(stock.getCode());
+        // unregister는 어디에서도 호출되지 않음(보상 로직 없음)
+        verify(orderSubscriptionCoordinator, never()).unregisterLimitOrder(stock.getCode());
+
+        // then: 주문/홀딩 금액은 롤백되어 DB에 남지 않음
+        List<Order> orders = orderRepository.findAllPendingOrdersByAccountId(
+                account.getAccountId(),
+                List.of(grit.stockIt.domain.order.entity.OrderStatus.PENDING)
+        );
+        assertThat(orders).isEmpty();
+        Account reloaded = accountRepository.findById(account.getAccountId()).orElseThrow();
+        assertThat(reloaded.getHoldAmount()).isEqualByComparingTo(BigDecimal.ZERO);
+
+        // 오더북에도 당연히 반영되지 않음(afterCommit 자체가 발화되지 않음)
+        verify(redisOrderBookRepository, never()).addOrder(any(Order.class));
+    }
+}

--- a/src/test/java/grit/stockIt/domain/order/service/OrderBookInvariantCharacterizationTest.java
+++ b/src/test/java/grit/stockIt/domain/order/service/OrderBookInvariantCharacterizationTest.java
@@ -27,6 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import reactor.core.publisher.Mono;
 
@@ -45,6 +46,12 @@ import static org.mockito.Mockito.verify;
 // 컨테이너·프로파일 설정은 IntegrationTestSupport 싱글턴을 상속.
 // 오더북(afterCommit) 불변식은 실 커밋에 의존하므로 테스트 메서드에 @Transactional을 붙이지 않는다
 // (스프링 @Transactional 롤백 테스트는 afterCommit 콜백을 발화시키지 않아 계획에서 금지됨).
+// 격리 경화: 이 클래스는 OrderCancelQueryCharacterizationTest와 동일한
+// @SpyBean(redisOrderBookRepository/orderSubscriptionCoordinator) + @MockBean(StockDetailService) 구성이라
+// 스프링이 캐시된 ApplicationContext(=동일 spy 싱글턴)를 재사용한다. @BeforeEach의 Mockito.reset()만으로는
+// 형제 클래스 간 invocation 누출을 완전히 배제할 수 없으므로, 클래스 종료 시 컨텍스트를 폐기해
+// 다음 클래스가 항상 새 spy 인스턴스를 받도록 구조적으로 격리한다(느리지만 결정적).
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @DisplayName("OrderService 오더북(afterCommit) 불변식 특성화 테스트 (Phase A, 프로덕션 무수정)")
 class OrderBookInvariantCharacterizationTest extends IntegrationTestSupport {
 

--- a/src/test/java/grit/stockIt/domain/order/service/OrderCancelQueryCharacterizationTest.java
+++ b/src/test/java/grit/stockIt/domain/order/service/OrderCancelQueryCharacterizationTest.java
@@ -33,6 +33,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
@@ -53,6 +54,12 @@ import static org.mockito.Mockito.verify;
 
 // OrderService Phase A 특성화: cancelOrder / getOrder / getPendingOrders / 인증 미보유 경로.
 // 현재 관찰 가능한 동작(버그 의심 b, f 포함)을 그대로 동결한다. 프로덕션 코드는 수정하지 않는다.
+// 격리 경화: 이 클래스는 OrderBookInvariantCharacterizationTest와 동일한
+// @SpyBean(redisOrderBookRepository/orderSubscriptionCoordinator) 구성이라 스프링이 캐시된
+// ApplicationContext(=동일 spy 싱글턴)를 재사용한다. @BeforeEach의 Mockito.reset()만으로는 형제
+// 클래스 간 invocation 누출을 완전히 배제할 수 없으므로, 클래스 종료 시 컨텍스트를 폐기해 다음
+// 클래스가 항상 새 spy 인스턴스를 받도록 구조적으로 격리한다(느리지만 결정적).
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @DisplayName("OrderService 취소·조회·권한 특성화 테스트 (통합 테스트)")
 class OrderCancelQueryCharacterizationTest extends IntegrationTestSupport {
 

--- a/src/test/java/grit/stockIt/domain/order/service/OrderCancelQueryCharacterizationTest.java
+++ b/src/test/java/grit/stockIt/domain/order/service/OrderCancelQueryCharacterizationTest.java
@@ -1,0 +1,452 @@
+package grit.stockIt.domain.order.service;
+
+import grit.stockIt.domain.account.entity.Account;
+import grit.stockIt.domain.account.entity.AccountStock;
+import grit.stockIt.domain.account.repository.AccountRepository;
+import grit.stockIt.domain.account.repository.AccountStockRepository;
+import grit.stockIt.domain.contest.entity.Contest;
+import grit.stockIt.domain.contest.repository.ContestRepository;
+import grit.stockIt.domain.member.entity.AuthProvider;
+import grit.stockIt.domain.member.entity.Member;
+import grit.stockIt.domain.member.repository.MemberRepository;
+import grit.stockIt.domain.order.dto.OrderResponse;
+import grit.stockIt.domain.order.dto.PendingOrdersResponse;
+import grit.stockIt.domain.order.entity.Order;
+import grit.stockIt.domain.order.entity.OrderHold;
+import grit.stockIt.domain.order.entity.OrderHoldStatus;
+import grit.stockIt.domain.order.entity.OrderMethod;
+import grit.stockIt.domain.order.entity.OrderStatus;
+import grit.stockIt.domain.order.repository.OrderHoldRepository;
+import grit.stockIt.domain.order.repository.OrderRepository;
+import grit.stockIt.domain.stock.entity.Stock;
+import grit.stockIt.domain.stock.repository.StockRepository;
+import grit.stockIt.global.exception.BadRequestException;
+import grit.stockIt.global.exception.ForbiddenException;
+import grit.stockIt.global.support.IntegrationTestSupport;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+// OrderService Phase A 특성화: cancelOrder / getOrder / getPendingOrders / 인증 미보유 경로.
+// 현재 관찰 가능한 동작(버그 의심 b, f 포함)을 그대로 동결한다. 프로덕션 코드는 수정하지 않는다.
+@DisplayName("OrderService 취소·조회·권한 특성화 테스트 (통합 테스트)")
+class OrderCancelQueryCharacterizationTest extends IntegrationTestSupport {
+
+    @Autowired
+    private OrderService orderService;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Autowired
+    private OrderHoldRepository orderHoldRepository;
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    @Autowired
+    private AccountStockRepository accountStockRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ContestRepository contestRepository;
+
+    @Autowired
+    private StockRepository stockRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    private Member member;
+    private Account account;
+    private Stock stock;
+
+    @BeforeEach
+    void setUp() {
+        String uniqueId = UUID.randomUUID().toString().substring(0, 8);
+
+        member = memberRepository.save(Member.builder()
+                .name("특성화 사용자 " + uniqueId)
+                .email("cancel-query-" + uniqueId + "@test.com")
+                .provider(AuthProvider.LOCAL)
+                .build());
+
+        Contest contest = contestRepository.save(Contest.builder()
+                .contestName("특성화 대회 " + uniqueId)
+                .startDate(LocalDateTime.now())
+                .seedMoney(10_000_000L)
+                .commissionRate(BigDecimal.ZERO)
+                .isDefault(false)
+                .build());
+
+        account = accountRepository.save(Account.builder()
+                .member(member)
+                .contest(contest)
+                .accountName("특성화 계좌 " + uniqueId)
+                .cash(new BigDecimal("100000000"))
+                .holdAmount(BigDecimal.ZERO)
+                .isDefault(false)
+                .build());
+
+        stock = stockRepository.save(Stock.builder()
+                .code("T" + uniqueId)
+                .name("특성화 종목 " + uniqueId)
+                .marketType("KOSPI")
+                .build());
+
+        authenticateAs(member.getEmail());
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private void authenticateAs(String email) {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(email, null, List.of()));
+    }
+
+    private Order saveLimitOrder(Account acc, Stock stk, OrderMethod method, BigDecimal price, int quantity) {
+        return orderRepository.save(Order.createLimitOrder(acc, stk, price, quantity, method));
+    }
+
+    private Order saveMarketOrder(Account acc, Stock stk, OrderMethod method, int quantity) {
+        return orderRepository.save(Order.createMarketOrder(acc, stk, quantity, method));
+    }
+
+    // BUY 홀딩 구성: Account.holdAmount 증가 + OrderHold 저장 (createLimitOrder 성공 경로 재현)
+    // OrderHold의 @MapsId(Order)가 같은 영속성 컨텍스트 내 관리 상태의 order를 요구하므로
+    // 단일 트랜잭션 안에서 재조회 후 생성한다.
+    private void grantBuyHold(Order order, Account acc, BigDecimal holdAmount) {
+        DefaultTransactionDefinition def = new DefaultTransactionDefinition();
+        def.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        TransactionStatus status = transactionManager.getTransaction(def);
+        try {
+            Account managedAccount = accountRepository.findById(acc.getAccountId()).orElseThrow();
+            Order managedOrder = orderRepository.findById(order.getOrderId()).orElseThrow();
+            managedAccount.increaseHoldAmount(holdAmount);
+            accountRepository.save(managedAccount);
+            orderHoldRepository.save(OrderHold.create(managedOrder, managedAccount, holdAmount));
+            transactionManager.commit(status);
+        } catch (RuntimeException e) {
+            transactionManager.rollback(status);
+            throw e;
+        }
+    }
+
+    // SELL 홀딩 구성: AccountStock.holdQuantity 증가 (applySellHold 재현)
+    private AccountStock grantSellHold(Account acc, Stock stk, int quantity, BigDecimal price) {
+        AccountStock accountStock = accountStockRepository.findByAccountAndStock(acc, stk)
+                .orElseGet(() -> accountStockRepository.save(AccountStock.create(acc, stk, quantity, price)));
+        accountStock.increaseHoldQuantity(quantity);
+        return accountStockRepository.save(accountStock);
+    }
+
+    private void forceCreatedAt(Long orderId, LocalDateTime createdAt) {
+        jdbcTemplate.update("UPDATE trade_order SET created_at = ? WHERE order_id = ?",
+                Timestamp.valueOf(createdAt), orderId);
+    }
+
+    // 15. PENDING(remaining>0) BUY 취소 — status=CANCELLED, releaseBuyHold로 Account.holdAmount 감소 + OrderHold.release
+    @Test
+    @DisplayName("PENDING BUY 취소 시 홀딩 금액이 해제되고 CANCELLED로 전이한다")
+    void cancelOrder_pendingBuy_releasesHoldAndCancels() {
+        BigDecimal price = new BigDecimal("10000");
+        Order order = saveLimitOrder(account, stock, OrderMethod.BUY, price, 5);
+        BigDecimal holdAmount = price.multiply(BigDecimal.valueOf(5));
+        grantBuyHold(order, account, holdAmount);
+
+        OrderResponse response = orderService.cancelOrder(order.getOrderId());
+
+        assertThat(response.status()).isEqualTo(OrderStatus.CANCELLED);
+
+        Order reloadedOrder = orderRepository.findById(order.getOrderId()).orElseThrow();
+        assertThat(reloadedOrder.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+
+        Account reloadedAccount = accountRepository.findById(account.getAccountId()).orElseThrow();
+        assertThat(reloadedAccount.getHoldAmount()).isEqualByComparingTo(BigDecimal.ZERO);
+
+        OrderHold reloadedHold = orderHoldRepository.findById(order.getOrderId()).orElseThrow();
+        assertThat(reloadedHold.getStatus()).isEqualTo(OrderHoldStatus.RELEASED);
+        assertThat(reloadedHold.getHoldAmount()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    // 16. PENDING(remaining>0) SELL 취소 — releaseSellHold로 AccountStock.holdQuantity 감소
+    @Test
+    @DisplayName("PENDING SELL 취소 시 보유주식 홀딩 수량이 해제되고 CANCELLED로 전이한다")
+    void cancelOrder_pendingSell_releasesHoldAndCancels() {
+        BigDecimal price = new BigDecimal("10000");
+        Order order = saveLimitOrder(account, stock, OrderMethod.SELL, price, 5);
+        grantSellHold(account, stock, 5, price);
+
+        OrderResponse response = orderService.cancelOrder(order.getOrderId());
+
+        assertThat(response.status()).isEqualTo(OrderStatus.CANCELLED);
+
+        AccountStock reloadedAccountStock = accountStockRepository.findByAccountAndStock(account, stock).orElseThrow();
+        assertThat(reloadedAccountStock.getHoldQuantity()).isEqualTo(0);
+    }
+
+    // 17. PARTIALLY_FILLED 취소 — remaining>0 경로 동일, 부분수량 반영 동결
+    @Test
+    @DisplayName("PARTIALLY_FILLED 주문 취소 시 남은 수량만큼만 홀딩이 해제된다")
+    void cancelOrder_partiallyFilledSell_releasesRemainingHoldOnly() {
+        BigDecimal price = new BigDecimal("10000");
+        Order order = saveLimitOrder(account, stock, OrderMethod.SELL, price, 10);
+        grantSellHold(account, stock, 10, price);
+
+        order.applyFill(4);
+        orderRepository.save(order);
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.PARTIALLY_FILLED);
+
+        OrderResponse response = orderService.cancelOrder(order.getOrderId());
+
+        assertThat(response.status()).isEqualTo(OrderStatus.CANCELLED);
+
+        Order reloadedOrder = orderRepository.findById(order.getOrderId()).orElseThrow();
+        assertThat(reloadedOrder.getFilledQuantity()).isEqualTo(4);
+        assertThat(reloadedOrder.getRemainingQuantity()).isEqualTo(6);
+
+        AccountStock reloadedAccountStock = accountStockRepository.findByAccountAndStock(account, stock).orElseThrow();
+        // 최초 홀딩 10 - 취소 시점 잔여수량 6 해제 = 4 남음 (부분체결분은 이미 홀딩에서 빠지지 않은 현재 동작 동결)
+        assertThat(reloadedAccountStock.getHoldQuantity()).isEqualTo(4);
+    }
+
+    // 18. remaining<=0 취소경로 — removeOrder/unregister 가드, releaseSellHold early return, status=CANCELLED
+    @Test
+    @DisplayName("remaining이 0인 주문을 취소해도 홀딩 해제 없이 CANCELLED로 전이한다")
+    void cancelOrder_zeroRemaining_earlyReturnsHoldReleaseButStillCancels() {
+        BigDecimal price = new BigDecimal("10000");
+        Order order = saveLimitOrder(account, stock, OrderMethod.SELL, price, 5);
+        grantSellHold(account, stock, 5, price);
+
+        // 데이터 이상 상태(잔여수량 0인데 상태는 PENDING) 재현: applyFill은 FILLED로 전이시키므로
+        // remaining<=0 취소경로(현재 status 체크에서 걸러지지 않는 경우)를 직접 구성한다.
+        jdbcTemplate.update("UPDATE trade_order SET filled_quantity = quantity WHERE order_id = ?", order.getOrderId());
+
+        OrderResponse response = orderService.cancelOrder(order.getOrderId());
+
+        assertThat(response.status()).isEqualTo(OrderStatus.CANCELLED);
+
+        Order reloadedOrder = orderRepository.findById(order.getOrderId()).orElseThrow();
+        assertThat(reloadedOrder.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+        assertThat(reloadedOrder.getRemainingQuantity()).isEqualTo(0);
+
+        AccountStock reloadedAccountStock = accountStockRepository.findByAccountAndStock(account, stock).orElseThrow();
+        assertThat(reloadedAccountStock.getHoldQuantity()).isEqualTo(5);
+    }
+
+    // 19. 이미 취소된 주문
+    @Test
+    @DisplayName("이미 취소된 주문을 다시 취소하면 BadRequestException이 발생한다")
+    void cancelOrder_alreadyCancelled_throwsBadRequest() {
+        Order order = saveLimitOrder(account, stock, OrderMethod.SELL, new BigDecimal("10000"), 3);
+        order.markCancelled();
+        orderRepository.save(order);
+
+        assertThatThrownBy(() -> orderService.cancelOrder(order.getOrderId()))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("이미 취소된 주문입니다.");
+    }
+
+    // 20. 이미 체결된 주문
+    @Test
+    @DisplayName("이미 체결된 주문을 취소하면 BadRequestException이 발생한다")
+    void cancelOrder_alreadyFilled_throwsBadRequest() {
+        Order order = saveLimitOrder(account, stock, OrderMethod.SELL, new BigDecimal("10000"), 3);
+        order.applyFill(3);
+        orderRepository.save(order);
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.FILLED);
+
+        assertThatThrownBy(() -> orderService.cancelOrder(order.getOrderId()))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("이미 체결된 주문은 취소할 수 없습니다.");
+    }
+
+    // 21. 주문 미존재
+    @Test
+    @DisplayName("존재하지 않는 주문을 취소하면 BadRequestException이 발생한다")
+    void cancelOrder_notFound_throwsBadRequest() {
+        assertThatThrownBy(() -> orderService.cancelOrder(999_999_999L))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("주문을 찾을 수 없습니다.");
+    }
+
+    // 22. BUY 취소 시 OrderHold 미존재 — 버그 b 현동작 동결: Account.holdAmount 감소 없음
+    @Test
+    @DisplayName("[버그 b 동결] OrderHold가 없는 BUY 주문을 취소해도 Account.holdAmount는 감소하지 않는다")
+    void cancelOrder_buyWithoutOrderHold_doesNotReleaseAccountHold() {
+        BigDecimal price = new BigDecimal("10000");
+        Order order = saveLimitOrder(account, stock, OrderMethod.BUY, price, 5);
+        BigDecimal holdAmount = price.multiply(BigDecimal.valueOf(5));
+        account.increaseHoldAmount(holdAmount);
+        accountRepository.save(account);
+        // 의도적으로 OrderHold 미생성 (홀딩 데이터 유실 재현)
+
+        OrderResponse response = orderService.cancelOrder(order.getOrderId());
+
+        assertThat(response.status()).isEqualTo(OrderStatus.CANCELLED);
+
+        Account reloadedAccount = accountRepository.findById(account.getAccountId()).orElseThrow();
+        assertThat(reloadedAccount.getHoldAmount()).isEqualByComparingTo(holdAmount);
+        assertThat(orderHoldRepository.findById(order.getOrderId())).isEmpty();
+    }
+
+    // 24. getOrder 성공 / 타인계좌 Forbidden / 미존재 BadRequest
+    @Test
+    @DisplayName("getOrder 성공 시 OrderResponse를 반환한다")
+    void getOrder_success_returnsOrderResponse() {
+        BigDecimal price = new BigDecimal("12000");
+        Order order = saveLimitOrder(account, stock, OrderMethod.BUY, price, 7);
+
+        OrderResponse response = orderService.getOrder(order.getOrderId());
+
+        assertThat(response.orderId()).isEqualTo(order.getOrderId());
+        assertThat(response.accountId()).isEqualTo(account.getAccountId());
+        assertThat(response.stockCode()).isEqualTo(stock.getCode());
+        assertThat(response.stockName()).isEqualTo(stock.getName());
+        assertThat(response.status()).isEqualTo(OrderStatus.PENDING);
+        assertThat(response.price()).isEqualByComparingTo(price);
+        assertThat(response.quantity()).isEqualTo(7);
+        assertThat(response.filledQuantity()).isEqualTo(0);
+        assertThat(response.remainingQuantity()).isEqualTo(7);
+    }
+
+    @Test
+    @DisplayName("getOrder는 타인 계좌 주문 조회 시 ForbiddenException을 발생시킨다")
+    void getOrder_otherAccountOrder_throwsForbidden() {
+        String otherUniqueId = UUID.randomUUID().toString().substring(0, 8);
+        Member otherMember = memberRepository.save(Member.builder()
+                .name("타인 " + otherUniqueId)
+                .email("cancel-query-other-" + otherUniqueId + "@test.com")
+                .provider(AuthProvider.LOCAL)
+                .build());
+        Contest otherContest = contestRepository.save(Contest.builder()
+                .contestName("타인 대회 " + otherUniqueId)
+                .startDate(LocalDateTime.now())
+                .seedMoney(10_000_000L)
+                .commissionRate(BigDecimal.ZERO)
+                .isDefault(false)
+                .build());
+        Account otherAccount = accountRepository.save(Account.builder()
+                .member(otherMember)
+                .contest(otherContest)
+                .accountName("타인 계좌 " + otherUniqueId)
+                .cash(new BigDecimal("100000000"))
+                .holdAmount(BigDecimal.ZERO)
+                .isDefault(false)
+                .build());
+
+        Order otherOrder = saveLimitOrder(otherAccount, stock, OrderMethod.BUY, new BigDecimal("10000"), 1);
+
+        assertThatThrownBy(() -> orderService.getOrder(otherOrder.getOrderId()))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage("해당 계좌에 대한 권한이 없습니다.");
+    }
+
+    @Test
+    @DisplayName("getOrder는 존재하지 않는 주문 조회 시 BadRequestException을 발생시킨다")
+    void getOrder_notFound_throwsBadRequest() {
+        assertThatThrownBy(() -> orderService.getOrder(999_999_999L))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("주문을 찾을 수 없습니다.");
+    }
+
+    // 25. getPendingOrders — PENDING/PARTIALLY_FILLED만, MARKET price=null 매핑, 개수/순서 동결, 계좌 미존재 BadRequest
+    @Test
+    @DisplayName("getPendingOrders는 PENDING/PARTIALLY_FILLED 주문만 최신순으로 반환하고 MARKET 가격은 null이다")
+    void getPendingOrders_returnsOnlyActiveOrdersInCreatedDescOrderWithMarketPriceNull() {
+        BigDecimal price = new BigDecimal("10000");
+
+        Order oldestPending = saveLimitOrder(account, stock, OrderMethod.BUY, price, 2);
+        forceCreatedAt(oldestPending.getOrderId(), LocalDateTime.now().minusMinutes(3));
+
+        Order middlePartial = saveLimitOrder(account, stock, OrderMethod.SELL, price, 6);
+        middlePartial.applyFill(2);
+        orderRepository.save(middlePartial);
+        forceCreatedAt(middlePartial.getOrderId(), LocalDateTime.now().minusMinutes(2));
+
+        Order newestMarket = saveMarketOrder(account, stock, OrderMethod.SELL, 4);
+        forceCreatedAt(newestMarket.getOrderId(), LocalDateTime.now().minusMinutes(1));
+
+        Order filledOrder = saveLimitOrder(account, stock, OrderMethod.BUY, price, 1);
+        filledOrder.applyFill(1);
+        orderRepository.save(filledOrder);
+
+        Order cancelledOrder = saveLimitOrder(account, stock, OrderMethod.BUY, price, 1);
+        cancelledOrder.markCancelled();
+        orderRepository.save(cancelledOrder);
+
+        PendingOrdersResponse response = orderService.getPendingOrders(account.getAccountId());
+
+        assertThat(response.orders()).hasSize(3);
+        assertThat(response.orders())
+                .extracting(PendingOrdersResponse.PendingOrderItem::orderId)
+                .containsExactly(newestMarket.getOrderId(), middlePartial.getOrderId(), oldestPending.getOrderId());
+
+        PendingOrdersResponse.PendingOrderItem marketItem = response.orders().get(0);
+        assertThat(marketItem.price()).isNull();
+        assertThat(marketItem.quantity()).isEqualTo(4);
+        assertThat(marketItem.remainingQuantity()).isEqualTo(4);
+
+        PendingOrdersResponse.PendingOrderItem partialItem = response.orders().get(1);
+        assertThat(partialItem.price()).isEqualByComparingTo(price);
+        assertThat(partialItem.remainingQuantity()).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("getPendingOrders는 존재하지 않는 계좌 조회 시 BadRequestException을 발생시킨다")
+    void getPendingOrders_accountNotFound_throwsBadRequest() {
+        assertThatThrownBy(() -> orderService.getPendingOrders(999_999_999L))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("계좌를 찾을 수 없습니다.");
+    }
+
+    // 26. 권한 미인증 — SecurityContext anonymous/null → Forbidden('로그인이 필요합니다')
+    @Test
+    @DisplayName("인증 정보가 없으면(SecurityContext 비어있음) ForbiddenException이 발생한다")
+    void getOrder_noAuthentication_throwsForbidden() {
+        Order order = saveLimitOrder(account, stock, OrderMethod.BUY, new BigDecimal("10000"), 1);
+        SecurityContextHolder.clearContext();
+
+        assertThatThrownBy(() -> orderService.getOrder(order.getOrderId()))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage("로그인이 필요합니다.");
+    }
+
+    @Test
+    @DisplayName("anonymousUser 인증이면 ForbiddenException이 발생한다")
+    void getOrder_anonymousAuthentication_throwsForbidden() {
+        Order order = saveLimitOrder(account, stock, OrderMethod.BUY, new BigDecimal("10000"), 1);
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken("anonymousUser", null, List.of()));
+
+        assertThatThrownBy(() -> orderService.getOrder(order.getOrderId()))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage("로그인이 필요합니다.");
+    }
+}

--- a/src/test/java/grit/stockIt/domain/order/service/OrderCancelQueryCharacterizationTest.java
+++ b/src/test/java/grit/stockIt/domain/order/service/OrderCancelQueryCharacterizationTest.java
@@ -6,6 +6,7 @@ import grit.stockIt.domain.account.repository.AccountRepository;
 import grit.stockIt.domain.account.repository.AccountStockRepository;
 import grit.stockIt.domain.contest.entity.Contest;
 import grit.stockIt.domain.contest.repository.ContestRepository;
+import grit.stockIt.domain.matching.repository.RedisOrderBookRepository;
 import grit.stockIt.domain.member.entity.AuthProvider;
 import grit.stockIt.domain.member.entity.Member;
 import grit.stockIt.domain.member.repository.MemberRepository;
@@ -23,11 +24,13 @@ import grit.stockIt.domain.stock.repository.StockRepository;
 import grit.stockIt.global.exception.BadRequestException;
 import grit.stockIt.global.exception.ForbiddenException;
 import grit.stockIt.global.support.IntegrationTestSupport;
+import grit.stockIt.global.websocket.manager.OrderSubscriptionCoordinator;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -44,6 +47,9 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 // OrderService Phase A 특성화: cancelOrder / getOrder / getPendingOrders / 인증 미보유 경로.
 // 현재 관찰 가능한 동작(버그 의심 b, f 포함)을 그대로 동결한다. 프로덕션 코드는 수정하지 않는다.
@@ -80,12 +86,20 @@ class OrderCancelQueryCharacterizationTest extends IntegrationTestSupport {
     @Autowired
     private PlatformTransactionManager transactionManager;
 
+    @SpyBean
+    private RedisOrderBookRepository redisOrderBookRepository;
+
+    @SpyBean
+    private OrderSubscriptionCoordinator orderSubscriptionCoordinator;
+
     private Member member;
     private Account account;
     private Stock stock;
 
     @BeforeEach
     void setUp() {
+        // @SpyBean은 캐시된 컨텍스트에서 테스트 간 공유되므로, 각 테스트 시작 시 호출기록을 초기화한다(격리).
+        org.mockito.Mockito.reset(redisOrderBookRepository, orderSubscriptionCoordinator);
         String uniqueId = UUID.randomUUID().toString().substring(0, 8);
 
         member = memberRepository.save(Member.builder()
@@ -193,6 +207,10 @@ class OrderCancelQueryCharacterizationTest extends IntegrationTestSupport {
         OrderHold reloadedHold = orderHoldRepository.findById(order.getOrderId()).orElseThrow();
         assertThat(reloadedHold.getStatus()).isEqualTo(OrderHoldStatus.RELEASED);
         assertThat(reloadedHold.getHoldAmount()).isEqualByComparingTo(BigDecimal.ZERO);
+
+        // 버그 f 동결: remaining>0 취소 시 removeOrder/unregisterLimitOrder가 커밋 전 동기 호출된다.
+        verify(redisOrderBookRepository, times(1)).removeOrder(order.getOrderId(), stock.getCode(), OrderMethod.BUY);
+        verify(orderSubscriptionCoordinator, times(1)).unregisterLimitOrder(stock.getCode());
     }
 
     // 16. PENDING(remaining>0) SELL 취소 — releaseSellHold로 AccountStock.holdQuantity 감소
@@ -209,6 +227,10 @@ class OrderCancelQueryCharacterizationTest extends IntegrationTestSupport {
 
         AccountStock reloadedAccountStock = accountStockRepository.findByAccountAndStock(account, stock).orElseThrow();
         assertThat(reloadedAccountStock.getHoldQuantity()).isEqualTo(0);
+
+        // 버그 f 동결: remaining>0 취소 시 removeOrder/unregisterLimitOrder가 커밋 전 동기 호출된다.
+        verify(redisOrderBookRepository, times(1)).removeOrder(order.getOrderId(), stock.getCode(), OrderMethod.SELL);
+        verify(orderSubscriptionCoordinator, times(1)).unregisterLimitOrder(stock.getCode());
     }
 
     // 17. PARTIALLY_FILLED 취소 — remaining>0 경로 동일, 부분수량 반영 동결
@@ -258,6 +280,10 @@ class OrderCancelQueryCharacterizationTest extends IntegrationTestSupport {
 
         AccountStock reloadedAccountStock = accountStockRepository.findByAccountAndStock(account, stock).orElseThrow();
         assertThat(reloadedAccountStock.getHoldQuantity()).isEqualTo(5);
+
+        // remaining<=0 가드 동결: removeOrder/unregisterLimitOrder는 호출되지 않는다.
+        verify(redisOrderBookRepository, never()).removeOrder(order.getOrderId(), stock.getCode(), OrderMethod.SELL);
+        verify(orderSubscriptionCoordinator, never()).unregisterLimitOrder(stock.getCode());
     }
 
     // 19. 이미 취소된 주문
@@ -271,6 +297,10 @@ class OrderCancelQueryCharacterizationTest extends IntegrationTestSupport {
         assertThatThrownBy(() -> orderService.cancelOrder(order.getOrderId()))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage("이미 취소된 주문입니다.");
+
+        // 상태 가드에서 조기 예외 발생 → 오더북/구독 코디네이터 미호출 동결.
+        verify(redisOrderBookRepository, never()).removeOrder(order.getOrderId(), stock.getCode(), OrderMethod.SELL);
+        verify(orderSubscriptionCoordinator, never()).unregisterLimitOrder(stock.getCode());
     }
 
     // 20. 이미 체결된 주문
@@ -285,6 +315,10 @@ class OrderCancelQueryCharacterizationTest extends IntegrationTestSupport {
         assertThatThrownBy(() -> orderService.cancelOrder(order.getOrderId()))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage("이미 체결된 주문은 취소할 수 없습니다.");
+
+        // 상태 가드에서 조기 예외 발생 → 오더북/구독 코디네이터 미호출 동결.
+        verify(redisOrderBookRepository, never()).removeOrder(order.getOrderId(), stock.getCode(), OrderMethod.SELL);
+        verify(orderSubscriptionCoordinator, never()).unregisterLimitOrder(stock.getCode());
     }
 
     // 21. 주문 미존재

--- a/src/test/java/grit/stockIt/domain/order/service/OrderCreateCharacterizationTest.java
+++ b/src/test/java/grit/stockIt/domain/order/service/OrderCreateCharacterizationTest.java
@@ -41,7 +41,6 @@ import reactor.core.publisher.Mono;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/grit/stockIt/domain/order/service/OrderCreateCharacterizationTest.java
+++ b/src/test/java/grit/stockIt/domain/order/service/OrderCreateCharacterizationTest.java
@@ -35,6 +35,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import reactor.core.publisher.Mono;
 
@@ -59,6 +60,11 @@ import static org.mockito.Mockito.when;
  * reuse 활성 환경에서 같은 해시의 공유 컨테이너를 클래스 종료 시 stop시켜, 캐시된 다른
  * 테스트 컨텍스트를 전멸시키는 원인이었다(동일 설정이라 동작은 그대로).
  */
+// 격리 경화: @SpyBean(orderSubscriptionCoordinator) 구성이 다른 특성화 클래스와 우연히 일치하면
+// 스프링이 캐시된 ApplicationContext(=동일 spy 싱글턴)를 재사용할 수 있다. @BeforeEach의
+// Mockito.reset()만으로는 형제 클래스 간 invocation 누출을 완전히 배제할 수 없으므로, 클래스 종료 시
+// 컨텍스트를 폐기해 다음 클래스가 항상 새 spy 인스턴스를 받도록 구조적으로 격리한다(느리지만 결정적).
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @DisplayName("OrderService 주문 생성 특성화 테스트 (통합 테스트)")
 class OrderCreateCharacterizationTest extends IntegrationTestSupport {
 

--- a/src/test/java/grit/stockIt/domain/order/service/OrderCreateCharacterizationTest.java
+++ b/src/test/java/grit/stockIt/domain/order/service/OrderCreateCharacterizationTest.java
@@ -26,12 +26,14 @@ import grit.stockIt.domain.stock.service.StockDetailService;
 import grit.stockIt.global.exception.BadRequestException;
 import grit.stockIt.global.exception.UntradeableStockException;
 import grit.stockIt.global.support.IntegrationTestSupport;
+import grit.stockIt.global.websocket.manager.OrderSubscriptionCoordinator;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import reactor.core.publisher.Mono;
@@ -45,6 +47,9 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -88,10 +93,15 @@ class OrderCreateCharacterizationTest extends IntegrationTestSupport {
     @MockBean
     private StockDetailService stockDetailService;
 
+    @SpyBean
+    private OrderSubscriptionCoordinator orderSubscriptionCoordinator;
+
     private String memberEmail;
 
     @BeforeEach
     void setUp() {
+        // @SpyBean은 캐시된 컨텍스트에서 테스트 간 공유되므로, 각 테스트 시작 시 호출기록을 초기화한다(격리).
+        org.mockito.Mockito.reset(orderSubscriptionCoordinator);
         memberEmail = "order-create-" + UUID.randomUUID() + "@test.com";
         // 기본적으로 거래 가능 종목으로 취급 (개별 테스트에서 필요 시 재정의)
         when(stockDetailService.getStockDetail(anyString()))
@@ -386,6 +396,10 @@ class OrderCreateCharacterizationTest extends IntegrationTestSupport {
 
         OrderHold hold = orderHoldRepository.findById(response.orderId()).orElseThrow();
         assertThat(hold.getHoldAmount()).isEqualByComparingTo(expectedHold);
+
+        // 버그 a 동결: registerLimitOrder는 save 이전 직접호출(선구독) 1회 + afterCommit의
+        // addOrderToRedisAfterCommit에서 재호출 1회 = 총 2회.
+        verify(orderSubscriptionCoordinator, times(2)).registerLimitOrder(fx.stock().getCode());
     }
 
     // ===== 9. 시장가 BUY 캐시미스 -> KIS성공 =====
@@ -499,6 +513,10 @@ class OrderCreateCharacterizationTest extends IntegrationTestSupport {
         AccountStock updated = accountStockRepository.findByAccountAndStock(fx.account(), fx.stock()).orElseThrow();
         assertThat(updated.getHoldQuantity()).isEqualTo(quantity);
         assertThat(orderHoldRepository.findById(response.orderId())).isEmpty();
+
+        // 버그 d 동결: SELL도 BUY와 동일하게 registerLimitOrder가 save 이전 직접호출(선구독) 1회 +
+        // afterCommit의 addOrderToRedisAfterCommit에서 재호출 1회 = 총 2회.
+        verify(orderSubscriptionCoordinator, times(2)).registerLimitOrder(fx.stock().getCode());
     }
 
     // ===== 14. 시장가 SELL 무보유 =====
@@ -515,6 +533,11 @@ class OrderCreateCharacterizationTest extends IntegrationTestSupport {
         assertThatThrownBy(() -> orderService.createMarketOrder(request))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage("보유 중인 종목이 없습니다.");
+
+        // 버그 d 동결: registerLimitOrder는 applySellHold(예외 발생 지점)보다 앞서 직접 호출되므로
+        // 트랜잭션 롤백과 무관하게 1회 호출 잔존. 보상(unregister) 로직 없음.
+        verify(orderSubscriptionCoordinator, times(1)).registerLimitOrder(fx.stock().getCode());
+        verify(orderSubscriptionCoordinator, never()).unregisterLimitOrder(fx.stock().getCode());
     }
 
     // ===== 23. applyBuyHold save 경계: 지정가/시장가 모두 OrderHold FK·금액 동결 =====

--- a/src/test/java/grit/stockIt/domain/order/service/OrderCreateCharacterizationTest.java
+++ b/src/test/java/grit/stockIt/domain/order/service/OrderCreateCharacterizationTest.java
@@ -1,0 +1,563 @@
+package grit.stockIt.domain.order.service;
+
+import grit.stockIt.domain.account.entity.Account;
+import grit.stockIt.domain.account.entity.AccountStock;
+import grit.stockIt.domain.account.repository.AccountRepository;
+import grit.stockIt.domain.account.repository.AccountStockRepository;
+import grit.stockIt.domain.contest.entity.Contest;
+import grit.stockIt.domain.contest.repository.ContestRepository;
+import grit.stockIt.domain.matching.repository.RedisMarketDataRepository;
+import grit.stockIt.domain.member.entity.AuthProvider;
+import grit.stockIt.domain.member.entity.Member;
+import grit.stockIt.domain.member.repository.MemberRepository;
+import grit.stockIt.domain.order.dto.LimitOrderCreateRequest;
+import grit.stockIt.domain.order.dto.MarketOrderCreateRequest;
+import grit.stockIt.domain.order.dto.OrderResponse;
+import grit.stockIt.domain.order.entity.OrderHold;
+import grit.stockIt.domain.order.entity.OrderMethod;
+import grit.stockIt.domain.order.entity.OrderStatus;
+import grit.stockIt.domain.order.entity.OrderType;
+import grit.stockIt.domain.order.repository.OrderHoldRepository;
+import grit.stockIt.domain.order.repository.OrderRepository;
+import grit.stockIt.domain.stock.dto.StockDetailResponse;
+import grit.stockIt.domain.stock.entity.Stock;
+import grit.stockIt.domain.stock.repository.StockRepository;
+import grit.stockIt.domain.stock.service.StockDetailService;
+import grit.stockIt.global.exception.BadRequestException;
+import grit.stockIt.global.exception.UntradeableStockException;
+import grit.stockIt.global.support.IntegrationTestSupport;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import reactor.core.publisher.Mono;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * OrderService 주문 생성(createLimitOrder/createMarketOrder) 특성화 테스트 (Phase A, 프로덕션 무수정).
+ * 현재 관찰 가능한 동작을 그대로 동결한다. 버그로 보이는 지점도 수정하지 않고 현재 동작대로 단언한다.
+ *
+ * 컨테이너·프로파일 설정은 IntegrationTestSupport 싱글턴을 상속 — 자체 @Container 선언은
+ * reuse 활성 환경에서 같은 해시의 공유 컨테이너를 클래스 종료 시 stop시켜, 캐시된 다른
+ * 테스트 컨텍스트를 전멸시키는 원인이었다(동일 설정이라 동작은 그대로).
+ */
+@DisplayName("OrderService 주문 생성 특성화 테스트 (통합 테스트)")
+class OrderCreateCharacterizationTest extends IntegrationTestSupport {
+
+    @Autowired
+    private OrderService orderService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ContestRepository contestRepository;
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    @Autowired
+    private StockRepository stockRepository;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Autowired
+    private OrderHoldRepository orderHoldRepository;
+
+    @Autowired
+    private AccountStockRepository accountStockRepository;
+
+    @Autowired
+    private RedisMarketDataRepository redisMarketDataRepository;
+
+    @MockBean
+    private StockDetailService stockDetailService;
+
+    private String memberEmail;
+
+    @BeforeEach
+    void setUp() {
+        memberEmail = "order-create-" + UUID.randomUUID() + "@test.com";
+        // 기본적으로 거래 가능 종목으로 취급 (개별 테스트에서 필요 시 재정의)
+        when(stockDetailService.getStockDetail(anyString()))
+                .thenReturn(Mono.just(tradeableStockDetail()));
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    // ===== 픽스처 헬퍼 =====
+
+    private String uniqueSuffix() {
+        return UUID.randomUUID().toString().substring(0, 8);
+    }
+
+    private Member createMember(String email) {
+        Member member = Member.builder()
+                .name("주문생성테스트 " + uniqueSuffix())
+                .email(email)
+                .provider(AuthProvider.LOCAL)
+                .build();
+        return memberRepository.save(member);
+    }
+
+    private Contest createContest() {
+        Contest contest = Contest.builder()
+                .contestName("주문생성테스트 대회 " + uniqueSuffix())
+                .startDate(java.time.LocalDateTime.now())
+                .seedMoney(10_000_000L)
+                .commissionRate(new BigDecimal("0.0000"))
+                .isDefault(false)
+                .build();
+        return contestRepository.save(contest);
+    }
+
+    private Account createAccount(Member member, Contest contest, BigDecimal cash) {
+        Account account = Account.builder()
+                .member(member)
+                .contest(contest)
+                .accountName("주문생성테스트 계좌 " + uniqueSuffix())
+                .cash(cash)
+                .holdAmount(BigDecimal.ZERO)
+                .isDefault(false)
+                .build();
+        return accountRepository.save(account);
+    }
+
+    private Stock createStock() {
+        Stock stock = Stock.builder()
+                .code("T" + uniqueSuffix())
+                .name("특성화종목 " + uniqueSuffix())
+                .marketType("KOSPI")
+                .build();
+        return stockRepository.save(stock);
+    }
+
+    /** email 소유자의 계좌 1개 + 종목 1개로 구성된 기본 시나리오 픽스처. */
+    private record Fixture(Member member, Contest contest, Account account, Stock stock) {
+    }
+
+    private Fixture createFixture(BigDecimal cash) {
+        Member member = createMember(memberEmail);
+        Contest contest = createContest();
+        Account account = createAccount(member, contest, cash);
+        Stock stock = createStock();
+        return new Fixture(member, contest, account, stock);
+    }
+
+    /** 동일 회원(memberEmail) 소유의 추가 계좌를 새 대회 하에 생성한다 (member 재생성으로 인한 email 유니크 제약 충돌 방지). */
+    private Fixture createAdditionalFixture(Member member, BigDecimal cash) {
+        Contest contest = createContest();
+        Account account = createAccount(member, contest, cash);
+        Stock stock = createStock();
+        return new Fixture(member, contest, account, stock);
+    }
+
+    private void authenticateAs(String email) {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(email, null, List.of()));
+    }
+
+    private StockDetailResponse tradeableStockDetail() {
+        return stockDetail(true, null);
+    }
+
+    private StockDetailResponse stockDetail(boolean tradeable, String untradeableReason) {
+        return new StockDetailResponse(
+                "IGNORED", "무시됨", 0, 0, "0", null,
+                0L, 0L, 0L, 0.0, 0.0, 0.0,
+                0, 0, 0, 0, 0,
+                null, null,
+                tradeable, untradeableReason,
+                null, null
+        );
+    }
+
+    private AccountStock createHolding(Account account, Stock stock, int quantity, BigDecimal avgPrice) {
+        AccountStock accountStock = AccountStock.create(account, stock, quantity, avgPrice);
+        return accountStockRepository.save(accountStock);
+    }
+
+    // ===== 1. 지정가 BUY 성공 =====
+
+    @Test
+    @DisplayName("createLimitOrder: BUY 성공 시 PENDING 주문·홀딩금액·OrderHold가 생성된다")
+    void createLimitOrder_buySuccess() {
+        Fixture fx = createFixture(new BigDecimal("1000000"));
+        authenticateAs(memberEmail);
+
+        BigDecimal price = new BigDecimal("10000");
+        int quantity = 5;
+        LimitOrderCreateRequest request = new LimitOrderCreateRequest(
+                fx.account().getAccountId(), fx.stock().getCode(), price, quantity, OrderMethod.BUY);
+
+        OrderResponse response = orderService.createLimitOrder(request);
+
+        assertThat(response.orderId()).isNotNull();
+        assertThat(response.accountId()).isEqualTo(fx.account().getAccountId());
+        assertThat(response.stockCode()).isEqualTo(fx.stock().getCode());
+        assertThat(response.orderType()).isEqualTo(OrderType.LIMIT);
+        assertThat(response.orderMethod()).isEqualTo(OrderMethod.BUY);
+        assertThat(response.status()).isEqualTo(OrderStatus.PENDING);
+        assertThat(response.price()).isEqualByComparingTo(price);
+        assertThat(response.quantity()).isEqualTo(quantity);
+        assertThat(response.filledQuantity()).isZero();
+        assertThat(response.remainingQuantity()).isEqualTo(quantity);
+
+        Account updatedAccount = accountRepository.findById(fx.account().getAccountId()).orElseThrow();
+        BigDecimal expectedHold = price.multiply(BigDecimal.valueOf(quantity));
+        assertThat(updatedAccount.getHoldAmount()).isEqualByComparingTo(expectedHold);
+
+        OrderHold hold = orderHoldRepository.findById(response.orderId()).orElseThrow();
+        assertThat(hold.getHoldAmount()).isEqualByComparingTo(expectedHold);
+        assertThat(hold.getAccount().getAccountId()).isEqualTo(fx.account().getAccountId());
+    }
+
+    // ===== 2. 지정가 SELL 성공 =====
+
+    @Test
+    @DisplayName("createLimitOrder: SELL 성공 시 AccountStock 홀딩수량만 증가하고 OrderHold는 생성되지 않는다")
+    void createLimitOrder_sellSuccess() {
+        Fixture fx = createFixture(new BigDecimal("1000000"));
+        createHolding(fx.account(), fx.stock(), 10, new BigDecimal("9000"));
+        authenticateAs(memberEmail);
+
+        int quantity = 4;
+        LimitOrderCreateRequest request = new LimitOrderCreateRequest(
+                fx.account().getAccountId(), fx.stock().getCode(), new BigDecimal("9500"), quantity, OrderMethod.SELL);
+
+        OrderResponse response = orderService.createLimitOrder(request);
+
+        assertThat(response.status()).isEqualTo(OrderStatus.PENDING);
+        assertThat(response.remainingQuantity()).isEqualTo(quantity);
+
+        AccountStock updated = accountStockRepository.findByAccountAndStock(fx.account(), fx.stock()).orElseThrow();
+        assertThat(updated.getHoldQuantity()).isEqualTo(quantity);
+
+        assertThat(orderHoldRepository.findById(response.orderId())).isEmpty();
+    }
+
+    // ===== 3. BUY 현금부족 =====
+
+    @Test
+    @DisplayName("createLimitOrder: BUY 현금부족 시 BadRequestException, DB 무변경")
+    void createLimitOrder_buyInsufficientCash() {
+        Fixture fx = createFixture(new BigDecimal("100"));
+        authenticateAs(memberEmail);
+
+        LimitOrderCreateRequest request = new LimitOrderCreateRequest(
+                fx.account().getAccountId(), fx.stock().getCode(), new BigDecimal("10000"), 5, OrderMethod.BUY);
+
+        assertThatThrownBy(() -> orderService.createLimitOrder(request))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("주문 가능 현금이 부족합니다.");
+
+        Account unchanged = accountRepository.findById(fx.account().getAccountId()).orElseThrow();
+        assertThat(unchanged.getHoldAmount()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(unchanged.getCash()).isEqualByComparingTo(new BigDecimal("100"));
+        assertThat(orderRepository.findByAccountIdAndStockCode(
+                fx.account().getAccountId(), fx.stock().getCode(), true, OrderStatus.CANCELLED)).isEmpty();
+    }
+
+    // ===== 4. 미거래종목 =====
+
+    @Test
+    @DisplayName("createLimitOrder: BUY 미거래종목(tradeable=false) 시 UntradeableStockException(사유 포함)")
+    void createLimitOrder_buyUntradeableStock() {
+        Fixture fx = createFixture(new BigDecimal("1000000"));
+        authenticateAs(memberEmail);
+        when(stockDetailService.getStockDetail(fx.stock().getCode()))
+                .thenReturn(Mono.just(stockDetail(false, "AI 분석 결과 거래가 제한됩니다.")));
+
+        LimitOrderCreateRequest request = new LimitOrderCreateRequest(
+                fx.account().getAccountId(), fx.stock().getCode(), new BigDecimal("10000"), 5, OrderMethod.BUY);
+
+        assertThatThrownBy(() -> orderService.createLimitOrder(request))
+                .isInstanceOf(UntradeableStockException.class)
+                .hasMessage("AI 분석 결과 거래가 제한됩니다.");
+    }
+
+    @Test
+    @DisplayName("createLimitOrder: BUY 거래가능 조회 중 일반 예외 발생 시에도 UntradeableStockException으로 뭉뚱그려진다(버그 e 동결)")
+    void createLimitOrder_buyStockDetailLookupFails_wrappedAsUntradeable() {
+        Fixture fx = createFixture(new BigDecimal("1000000"));
+        authenticateAs(memberEmail);
+        when(stockDetailService.getStockDetail(fx.stock().getCode()))
+                .thenReturn(Mono.error(new RuntimeException("KIS 연결 실패")));
+
+        LimitOrderCreateRequest request = new LimitOrderCreateRequest(
+                fx.account().getAccountId(), fx.stock().getCode(), new BigDecimal("10000"), 5, OrderMethod.BUY);
+
+        assertThatThrownBy(() -> orderService.createLimitOrder(request))
+                .isInstanceOf(UntradeableStockException.class)
+                .hasMessage("종목 거래 가능 여부를 확인할 수 없습니다.");
+    }
+
+    // ===== 5. orderMethod null =====
+
+    @Test
+    @DisplayName("createLimitOrder: orderMethod null 시 BadRequestException")
+    void createLimitOrder_orderMethodNull() {
+        Fixture fx = createFixture(new BigDecimal("1000000"));
+        authenticateAs(memberEmail);
+
+        LimitOrderCreateRequest request = new LimitOrderCreateRequest(
+                fx.account().getAccountId(), fx.stock().getCode(), new BigDecimal("10000"), 5, null);
+
+        assertThatThrownBy(() -> orderService.createLimitOrder(request))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("매수/매도 구분이 필요합니다.");
+    }
+
+    // ===== 6. 계좌 미존재 =====
+
+    @Test
+    @DisplayName("createLimitOrder: 계좌 미존재 시 BadRequestException")
+    void createLimitOrder_accountNotFound() {
+        authenticateAs(memberEmail);
+        LimitOrderCreateRequest request = new LimitOrderCreateRequest(
+                -999L, "ANY", new BigDecimal("10000"), 5, OrderMethod.BUY);
+
+        assertThatThrownBy(() -> orderService.createLimitOrder(request))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("계좌를 찾을 수 없습니다.");
+    }
+
+    // ===== 7. 종목 미존재 =====
+
+    @Test
+    @DisplayName("createLimitOrder: 종목 미존재 시 BadRequestException")
+    void createLimitOrder_stockNotFound() {
+        Fixture fx = createFixture(new BigDecimal("1000000"));
+        authenticateAs(memberEmail);
+
+        LimitOrderCreateRequest request = new LimitOrderCreateRequest(
+                fx.account().getAccountId(), "NOPE-" + uniqueSuffix(), new BigDecimal("10000"), 5, OrderMethod.BUY);
+
+        assertThatThrownBy(() -> orderService.createLimitOrder(request))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("존재하지 않는 종목입니다.");
+    }
+
+    // ===== 8. 시장가 BUY 캐시적중 =====
+
+    @Test
+    @DisplayName("createMarketOrder: BUY 캐시적중 시 lastPrice*qty*(1+buffer)로 홀딩금액이 계산된다")
+    void createMarketOrder_buyCacheHit() {
+        Fixture fx = createFixture(new BigDecimal("1000000"));
+        authenticateAs(memberEmail);
+
+        BigDecimal lastPrice = new BigDecimal("12345");
+        int quantity = 3;
+        redisMarketDataRepository.updateLastPrice(fx.stock().getCode(), lastPrice);
+
+        MarketOrderCreateRequest request = new MarketOrderCreateRequest(
+                fx.account().getAccountId(), fx.stock().getCode(), quantity, OrderMethod.BUY);
+
+        OrderResponse response = orderService.createMarketOrder(request);
+
+        assertThat(response.orderType()).isEqualTo(OrderType.MARKET);
+        assertThat(response.status()).isEqualTo(OrderStatus.PENDING);
+        assertThat(response.remainingQuantity()).isEqualTo(quantity);
+
+        BigDecimal expectedHold = lastPrice.multiply(BigDecimal.valueOf(quantity))
+                .multiply(new BigDecimal("1.05"))
+                .setScale(2, RoundingMode.UP);
+
+        Account updated = accountRepository.findById(fx.account().getAccountId()).orElseThrow();
+        assertThat(updated.getHoldAmount()).isEqualByComparingTo(expectedHold);
+
+        OrderHold hold = orderHoldRepository.findById(response.orderId()).orElseThrow();
+        assertThat(hold.getHoldAmount()).isEqualByComparingTo(expectedHold);
+    }
+
+    // ===== 9. 시장가 BUY 캐시미스 -> KIS성공 =====
+
+    @Test
+    @DisplayName("createMarketOrder: BUY 캐시미스 시 KIS 현재가로 홀딩금액을 계산한다")
+    void createMarketOrder_buyCacheMissKisSuccess() {
+        Fixture fx = createFixture(new BigDecimal("1000000"));
+        authenticateAs(memberEmail);
+
+        BigDecimal kisPrice = new BigDecimal("20000");
+        int quantity = 2;
+        when(stockDetailService.getCurrentPrice(fx.stock().getCode())).thenReturn(Mono.just(kisPrice));
+
+        MarketOrderCreateRequest request = new MarketOrderCreateRequest(
+                fx.account().getAccountId(), fx.stock().getCode(), quantity, OrderMethod.BUY);
+
+        OrderResponse response = orderService.createMarketOrder(request);
+
+        BigDecimal expectedHold = kisPrice.multiply(BigDecimal.valueOf(quantity))
+                .multiply(new BigDecimal("1.05"))
+                .setScale(2, RoundingMode.UP);
+
+        Account updated = accountRepository.findById(fx.account().getAccountId()).orElseThrow();
+        assertThat(updated.getHoldAmount()).isEqualByComparingTo(expectedHold);
+        assertThat(response.status()).isEqualTo(OrderStatus.PENDING);
+    }
+
+    // ===== 10. 시장가 BUY 캐시미스 -> KIS실패 =====
+
+    @Test
+    @DisplayName("createMarketOrder: BUY 캐시미스 + KIS 실패 시 BadRequestException('최근 체결가 정보를 찾을 수 없습니다.')")
+    void createMarketOrder_buyCacheMissKisFailure() {
+        Fixture fx = createFixture(new BigDecimal("1000000"));
+        authenticateAs(memberEmail);
+
+        when(stockDetailService.getCurrentPrice(fx.stock().getCode()))
+                .thenReturn(Mono.error(new RuntimeException("KIS 오류")));
+
+        MarketOrderCreateRequest request = new MarketOrderCreateRequest(
+                fx.account().getAccountId(), fx.stock().getCode(), 2, OrderMethod.BUY);
+
+        assertThatThrownBy(() -> orderService.createMarketOrder(request))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("최근 체결가 정보를 찾을 수 없습니다.");
+
+        assertThat(orderRepository.findByAccountIdAndStockCode(
+                fx.account().getAccountId(), fx.stock().getCode(), true, OrderStatus.CANCELLED)).isEmpty();
+    }
+
+    // ===== 11. 시장가 BUY 현금부족 =====
+
+    @Test
+    @DisplayName("createMarketOrder: BUY 현금부족 시 BadRequestException, 롤백된다")
+    void createMarketOrder_buyInsufficientCash() {
+        Fixture fx = createFixture(new BigDecimal("100"));
+        authenticateAs(memberEmail);
+
+        BigDecimal lastPrice = new BigDecimal("50000");
+        redisMarketDataRepository.updateLastPrice(fx.stock().getCode(), lastPrice);
+
+        MarketOrderCreateRequest request = new MarketOrderCreateRequest(
+                fx.account().getAccountId(), fx.stock().getCode(), 5, OrderMethod.BUY);
+
+        assertThatThrownBy(() -> orderService.createMarketOrder(request))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("주문 가능 현금이 부족합니다.");
+
+        Account unchanged = accountRepository.findById(fx.account().getAccountId()).orElseThrow();
+        assertThat(unchanged.getHoldAmount()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(orderRepository.findByAccountIdAndStockCode(
+                fx.account().getAccountId(), fx.stock().getCode(), true, OrderStatus.CANCELLED)).isEmpty();
+    }
+
+    // ===== 12. 시장가 BUY 캐시적중 무효가 =====
+
+    @Test
+    @DisplayName("createMarketOrder: 캐시 최근가가 0 이하이면 BadRequestException('최근 체결가가 유효하지 않습니다.')")
+    void createMarketOrder_buyCacheHitInvalidPrice() {
+        Fixture fx = createFixture(new BigDecimal("1000000"));
+        authenticateAs(memberEmail);
+
+        redisMarketDataRepository.updateLastPrice(fx.stock().getCode(), BigDecimal.ZERO);
+
+        MarketOrderCreateRequest request = new MarketOrderCreateRequest(
+                fx.account().getAccountId(), fx.stock().getCode(), 3, OrderMethod.BUY);
+
+        assertThatThrownBy(() -> orderService.createMarketOrder(request))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("최근 체결가가 유효하지 않습니다.");
+    }
+
+    // ===== 13. 시장가 SELL 성공 =====
+
+    @Test
+    @DisplayName("createMarketOrder: SELL 성공 시 AccountStock 홀딩수량이 증가한다")
+    void createMarketOrder_sellSuccess() {
+        Fixture fx = createFixture(new BigDecimal("1000000"));
+        createHolding(fx.account(), fx.stock(), 10, new BigDecimal("9000"));
+        authenticateAs(memberEmail);
+
+        int quantity = 6;
+        MarketOrderCreateRequest request = new MarketOrderCreateRequest(
+                fx.account().getAccountId(), fx.stock().getCode(), quantity, OrderMethod.SELL);
+
+        OrderResponse response = orderService.createMarketOrder(request);
+
+        assertThat(response.orderType()).isEqualTo(OrderType.MARKET);
+        assertThat(response.status()).isEqualTo(OrderStatus.PENDING);
+
+        AccountStock updated = accountStockRepository.findByAccountAndStock(fx.account(), fx.stock()).orElseThrow();
+        assertThat(updated.getHoldQuantity()).isEqualTo(quantity);
+        assertThat(orderHoldRepository.findById(response.orderId())).isEmpty();
+    }
+
+    // ===== 14. 시장가 SELL 무보유 =====
+
+    @Test
+    @DisplayName("createMarketOrder: SELL 시 보유 종목이 없으면 BadRequestException('보유 중인 종목이 없습니다.')")
+    void createMarketOrder_sellNoHolding() {
+        Fixture fx = createFixture(new BigDecimal("1000000"));
+        authenticateAs(memberEmail);
+
+        MarketOrderCreateRequest request = new MarketOrderCreateRequest(
+                fx.account().getAccountId(), fx.stock().getCode(), 3, OrderMethod.SELL);
+
+        assertThatThrownBy(() -> orderService.createMarketOrder(request))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("보유 중인 종목이 없습니다.");
+    }
+
+    // ===== 23. applyBuyHold save 경계: 지정가/시장가 모두 OrderHold FK·금액 동결 =====
+
+    @Test
+    @DisplayName("applyBuyHold: 지정가·시장가 BUY 성공 시 OrderHold.orderId가 저장된 Order FK와 일치하고 금액이 정확하다")
+    void applyBuyHold_saveBoundary_limitAndMarket() {
+        // 지정가
+        Fixture limitFx = createFixture(new BigDecimal("1000000"));
+        authenticateAs(memberEmail);
+        BigDecimal limitPrice = new BigDecimal("8000");
+        int limitQty = 10;
+        LimitOrderCreateRequest limitRequest = new LimitOrderCreateRequest(
+                limitFx.account().getAccountId(), limitFx.stock().getCode(), limitPrice, limitQty, OrderMethod.BUY);
+        OrderResponse limitResponse = orderService.createLimitOrder(limitRequest);
+
+        assertThat(orderRepository.existsById(limitResponse.orderId())).isTrue();
+        OrderHold limitHold = orderHoldRepository.findById(limitResponse.orderId()).orElseThrow();
+        assertThat(limitHold.getOrderId()).isEqualTo(limitResponse.orderId());
+        assertThat(limitHold.getOrder().getOrderId()).isEqualTo(limitResponse.orderId());
+        BigDecimal expectedLimitHold = limitPrice.multiply(BigDecimal.valueOf(limitQty));
+        assertThat(limitHold.getHoldAmount()).isEqualByComparingTo(expectedLimitHold);
+        Account limitAccount = accountRepository.findById(limitFx.account().getAccountId()).orElseThrow();
+        assertThat(limitAccount.getHoldAmount()).isEqualByComparingTo(expectedLimitHold);
+
+        // 시장가 (별도 픽스처, 같은 인증 이메일)
+        Fixture marketFx = createAdditionalFixture(limitFx.member(), new BigDecimal("1000000"));
+        BigDecimal lastPrice = new BigDecimal("15000");
+        int marketQty = 4;
+        redisMarketDataRepository.updateLastPrice(marketFx.stock().getCode(), lastPrice);
+        MarketOrderCreateRequest marketRequest = new MarketOrderCreateRequest(
+                marketFx.account().getAccountId(), marketFx.stock().getCode(), marketQty, OrderMethod.BUY);
+        OrderResponse marketResponse = orderService.createMarketOrder(marketRequest);
+
+        assertThat(orderRepository.existsById(marketResponse.orderId())).isTrue();
+        OrderHold marketHold = orderHoldRepository.findById(marketResponse.orderId()).orElseThrow();
+        assertThat(marketHold.getOrderId()).isEqualTo(marketResponse.orderId());
+        assertThat(marketHold.getOrder().getOrderId()).isEqualTo(marketResponse.orderId());
+        BigDecimal expectedMarketHold = lastPrice.multiply(BigDecimal.valueOf(marketQty))
+                .multiply(new BigDecimal("1.05"))
+                .setScale(2, RoundingMode.UP);
+        assertThat(marketHold.getHoldAmount()).isEqualByComparingTo(expectedMarketHold);
+        Account marketAccount = accountRepository.findById(marketFx.account().getAccountId()).orElseThrow();
+        assertThat(marketAccount.getHoldAmount()).isEqualByComparingTo(expectedMarketHold);
+    }
+}


### PR DESCRIPTION
### 🚀 Summary

테스트 0개였던 `OrderService`(373줄, 의존 9, public 5/private 10, 핵심 자금 흐름)를 **특성화 테스트로 현재 동작을 동결한 뒤** 책임별 4개 컴포넌트 + 슬림 오케스트레이터로 분해했습니다. **관찰 가능한 동작은 변경 없음**(의도된 동작 변경 0건), order/service 라인 커버리지 0% → **97.3%**.

> 직전 mission 리팩토링(PR #204, develop 머지)과 동일 파이프라인(deep-interview → ralplan 합의 → 승인 → ultragoal)으로 진행했습니다.

---

### 📝 변경 사항

**Phase A — 안전망 (프로덕션 무수정)**
- OrderService 특성화 테스트 3클래스 **35 시나리오**(28 단언그룹): createLimitOrder/createMarketOrder/cancelOrder/getOrder/getPendingOrders + afterCommit 불변식 + 버그 의심 a~f 동결
- 하네스: `IntegrationTestSupport` 재사용(Testcontainers PG15+Redis7 싱글턴), KIS `@MockBean`, 오더북/코디네이터 `@SpyBean`, 커밋기반 afterCommit·예외기반 롤백. spy 격리는 `@DirtiesContext`로 결정적 보장

**Phase B — OrderService 4단계 분해 (373 → 221줄, leaf→sink)**
- `OrderAuthorizationService`(권한/인증) · `OrderPricingService`(계산+KIS, readOnly) · `OrderHoldService`(현금/주식 홀딩) · `OrderBookRegistrationService`(afterCommit 오더북 등록 불변식 소유)
- 의존 그래프 순환 없는 DAG, 이동 메서드 본문 원본과 정규화 대조 **IDENTICAL**(applyBuyHold 승격 예외)

**Phase C — 최종 검증**
- `./gradlew clean build` **195/0/0** green, order/service 커버리지 **97.3%**(≥70%), `docs/order-refactor-changes.md`(변경 목록 빈 + 버그 a~f 판정 요청)

---

### 🏷️ 변경 유형

- [ ] ✨ 기능 (feat)
- [ ] 🐛 버그 수정 (fix)
- [x] ♻️ 리팩토링 (refactor)
- [x] 📑 문서 (docs)
- [ ] 🧭 환경설정 / 인프라 (chore)
- [ ] ⚠️ Breaking change (기존 동작/API 변경) — 해당 없음 (동작·API 계약 무변경)

---

### ✅ 테스트 / 검증 방법

- `./gradlew clean build` — 전체 스위트 **195 통과 / 0 실패** (skip 3 = 기존 외부 연동 수동 테스트), checkstyle + ArchUnit 포함
- `./gradlew jacocoTestReport` — order/service 라인 커버리지 **97.3%**(182/187), order 전체 90.5%
- 동작 보존 증빙:
  - 특성화 35 테스트가 분해 4커밋 전반에 **단언 무수정**으로 통과(public API 보존 분해)
  - 이동 메서드 본문 원본과 정규화 대조 → IDENTICAL(applyBuyHold 승격, registerAfterCommit warn-log 부가만 예외)
  - afterCommit 유령주문 방지 불변식·트랜잭션 시맨틱스(오케스트레이터 메서드레벨 @Transactional, C1 readOnly, C3 무트랜잭션) 보존
- 정합성: Checkstyle 0경고, ArchUnit green, `suppressions.xml`·`archunit_store`·DTO 필드 **diff 0**
- spy 격리 플레이크: `@DirtiesContext` 경화 후 8~10회 연속 green

---

### 🖼️ 실행 결과 / 스크린샷

해당 없음 (내부 구조 리팩토링, UI·API 응답 변화 없음)

---

### 🔀 배포 / 마이그레이션 노트

없음 (DB 스키마·Flyway·환경변수 변경 없음)

---

### ☑️ 체크리스트

- [x] 셀프 리뷰를 완료했습니다
- [x] 코드 컨벤션(네이밍 / DTO / REST 경로)을 따랐습니다 — `{Domain}{역할}Service`, 파일당 최상위 클래스 1개
- [x] 테스트를 추가/수정했고 통과합니다
- [x] 필요한 문서(README / AGENTS / docs)를 갱신했습니다 — `docs/order-refactor-changes.md`
- [x] 시크릿·민감 정보가 커밋에 포함되지 않았습니다

---

### 리뷰어 주목 포인트

1. **`docs/order-refactor-changes.md`의 버그 의심 6건(a~f)** — 이번 PR에서 **수정하지 않고** 특성화로 동결 + 판정 요청으로 남겼습니다(동작 변경이라 별도 PR 대상). 우선 검토 권장:
   - **(f)** 취소 시 Redis 변이를 커밋 전 동기 실행 → 롤백 시 오더북만 제거·주문 미취소(유령/refcount 누수). 생성 경로의 'DB커밋후 Redis' 불변식과 비대칭
   - **(c)/(e)** KIS 폴백·거래가능 검증이 인프라 오류(timeout/5xx)를 BadRequest·UntradeableStock으로 포괄 은폐(원인 소실)
   - (a) 시장가 선구독 이중 등록, (b) OrderHold 유실 시 현금 잠김, (d) 시장가 SELL 선구독 순서
2. **버그로 보이는 동작도 특성화가 그대로 단언**합니다 — "왜 이 동작을 기대하지?" 싶은 부분은 의도된 현재 동작 고정입니다.

> 참고: 실행 검증 산출물(`build/qa-artifacts/`)은 gitignore 대상이라 PR에 미포함.

---

### 🎲 관련 이슈

close #
